### PR TITLE
Use of -Wwrite-strings and -Wextra throw up compiler warnings

### DIFF
--- a/dtls.c
+++ b/dtls.c
@@ -671,7 +671,7 @@ static void dtls_debug_keyblock(dtls_security_parameters_t *config)
   * see IANA for a full list of types:
   * https://www.iana.org/assignments/tls-parameters/tls-parameters.xml#tls-parameters-7
   */
-static char *dtls_handshake_type_to_name(int type)
+static const char *dtls_handshake_type_to_name(int type)
 {
   switch (type) {
   case DTLS_HT_HELLO_REQUEST:

--- a/dtls_debug.c
+++ b/dtls_debug.c
@@ -60,7 +60,7 @@ dtls_set_log_level(log_t level) {
 }
 
 /* this array has the same order as the type log_t */
-static char *loglevels[] = {
+static const char *loglevels[] = {
   "EMRG", "ALRT", "CRIT", "WARN", "NOTE", "INFO", "DEBG"
 };
 
@@ -214,7 +214,7 @@ dsrv_print_addr(const session_t *addr, char *buf, size_t len) {
 
 #ifndef WITH_CONTIKI
 void
-dsrv_log(log_t level, char *format, ...) {
+dsrv_log(log_t level, const char *format, ...) {
   static char timebuf[32];
   va_list ap;
   FILE *log_fd;

--- a/dtls_debug.h
+++ b/dtls_debug.h
@@ -74,7 +74,11 @@ void dtls_set_log_level(log_t level);
  * level is below or equal to the log level that set by
  * set_log_level(). */
 #ifdef HAVE_VPRINTF
-void dsrv_log(log_t level, char *format, ...);
+#if (defined(__GNUC__))
+void dsrv_log(log_t level, const char *format, ...) __attribute__ ((format(printf, 2, 3)));
+#else /* !__GNUC__ */
+void dsrv_log(log_t level, const char *format, ...);
+#endif /* !__GNUC__ */
 #else
 #define dsrv_log(level, format, ...) PRINTF(format, ##__VA_ARGS__)
 #endif

--- a/sha2/sha2.c
+++ b/sha2/sha2.c
@@ -251,7 +251,7 @@ void dtls_sha512_transform(dtls_sha512_ctx*, const sha2_word64*);
 #ifdef WITH_SHA256
 /*** SHA-XYZ INITIAL HASH VALUES AND CONSTANTS ************************/
 /* Hash constant words K for SHA-256: */
-const static sha2_word32 K256[64] = {
+static const sha2_word32 K256[64] = {
 	0x428a2f98UL, 0x71374491UL, 0xb5c0fbcfUL, 0xe9b5dba5UL,
 	0x3956c25bUL, 0x59f111f1UL, 0x923f82a4UL, 0xab1c5ed5UL,
 	0xd807aa98UL, 0x12835b01UL, 0x243185beUL, 0x550c7dc3UL,
@@ -271,7 +271,7 @@ const static sha2_word32 K256[64] = {
 };
 
 /* Initial hash value H for SHA-256: */
-const static sha2_word32 sha256_initial_hash_value[8] = {
+static const sha2_word32 sha256_initial_hash_value[8] = {
 	0x6a09e667UL,
 	0xbb67ae85UL,
 	0x3c6ef372UL,
@@ -584,7 +584,7 @@ void dtls_sha256_update(dtls_sha256_ctx* context, const sha2_byte *data, size_t 
 	}
 	while (len >= DTLS_SHA256_BLOCK_LENGTH) {
 		/* Process as many complete blocks as we can */
-		dtls_sha256_transform(context, (sha2_word32*)data);
+		dtls_sha256_transform(context, (const sha2_word32*)data);
 		context->bitcount += DTLS_SHA256_BLOCK_LENGTH << 3;
 		len -= DTLS_SHA256_BLOCK_LENGTH;
 		data += DTLS_SHA256_BLOCK_LENGTH;


### PR DESCRIPTION
dtls.c:
Add in const for dtls_handshake_type_to_name()

dtls_debug.[ch]:

Add in const where appropriate for dsrv_log().
In addition, get dsrv_log() to check printf syntax.

sha2/sha2.c:

Re-order "const static" to "static const" and add in needed const.

Signed-off-by: Jon Shallow <supjps-libcoap@jpshallow.com>