### PR TITLE
Correct printf formatting errors when using dsrv_log()

### DIFF
--- a/tests/dtls-client.c
+++ b/tests/dtls-client.c
@@ -114,7 +114,7 @@ get_psk_info(struct dtls_context_t *ctx UNUSED_PARAM,
   switch (type) {
   case DTLS_PSK_IDENTITY:
     if (id_len) {
-      dtls_debug("got psk_identity_hint: '%.*s'\n", id_len, id);
+      dtls_debug("got psk_identity_hint: '%.*s'\n", (int)id_len, id);
     }
 
     if (result_length < psk_id_length) {

--- a/tests/dtls-server.c
+++ b/tests/dtls-server.c
@@ -169,7 +169,7 @@ dtls_handle_read(struct dtls_context_t *ctx) {
     dtls_debug("got %d bytes from port %d\n", len, 
 	     ntohs(session.addr.sin6.sin6_port));
     if (sizeof(buf) < len) {
-      dtls_warn("packet was truncated (%d bytes lost)\n", len - sizeof(buf));
+      dtls_warn("packet was truncated (%ld bytes lost)\n", len - sizeof(buf));
     }
   }
 


### PR DESCRIPTION
tests/dtls-client.c:
tests/dtls-server.c:

Correct parameters when calling dtls_debug() or dtls_warn().

Signed-off-by: Jon Shallow <supjps-libcoap@jpshallow.com>