### PR TITLE
dtls_send_client_key_exchange does not preset all bytes before being sent out

### DIFF
--- a/dtls.c
+++ b/dtls.c
@@ -2333,6 +2333,7 @@ dtls_send_client_key_exchange(dtls_context_t *ctx, dtls_peer_t *peer)
 
   p = buf;
 
+  memset(buf, 0, sizeof(buf));
   switch (handshake->cipher) {
 #ifdef DTLS_PSK
   case TLS_PSK_WITH_AES_128_CCM_8: {


### PR DESCRIPTION
Seen in the client when using using tinydtls client and tinydtls server 
with a mismatch of PSK keys. See PR #8 comments for example of valgrind output.

dtls.c:

Clear out the on stack buf variable to zero in dtls_send_client_key_exchange() 
before adding in encrypted data (which could be rounded up to a block size) 
later on in the function.

Example valgrind output

==8967== Syscall param socketcall.sendto(msg) points to uninitialised byte(s)
==8967==    at 0x5121AB2: send (in /lib64/libc-2.12.so)
==8967==    by 0x407863: coap_network_send (coap_io.c:767)
==8967==    by 0x4093AE: coap_socket_send (coap_io.c:1424)
==8967==    by 0x409FBE: coap_session_send (coap_session.c:229)
==8967==    by 0x40CAE0: dtls_send_to_peer (coap_tinydtls.c:105)
==8967==    by 0x4202AF: dtls_send_multi (in /usr/bin/coap-client)
==8967==    by 0x41FEDC: dtls_send_handshake_msg_hash (in /usr/bin/coap-client)
==8967==    by 0x41FF3D: dtls_send_handshake_msg (in /usr/bin/coap-client)
==8967==    by 0x421CB3: dtls_send_client_key_exchange (in /usr/bin/coap-client)
==8967==    by 0x42300B: check_server_hellodone (in /usr/bin/coap-client)
==8967==    by 0x4238FC: handle_handshake_msg (in /usr/bin/coap-client)
==8967==    by 0x42463D: handle_handshake (in /usr/bin/coap-client)
==8967==  Address 0x7feffeddf is on thread 1's stack
==8967==  Uninitialised value was created by a stack allocation
==8967==    at 0x421984: dtls_send_client_key_exchange (in /usr/bin/coap-client)
==8967==
==8967== Use of uninitialised value of size 8
==8967==    at 0x429BE5: rijndaelEncrypt (in /usr/bin/coap-client)
==8967==    by 0x42A3E4: rijndael_encrypt (in /usr/bin/coap-client)
==8967==    by 0x4277C3: mac (in /usr/bin/coap-client)
==8967==    by 0x4278CE: dtls_ccm_encrypt_message (in /usr/bin/coap-client)
==8967==    by 0x426749: dtls_ccm_encrypt (in /usr/bin/coap-client)
==8967==    by 0x427101: dtls_encrypt (in /usr/bin/coap-client)
==8967==    by 0x41FD0E: dtls_prepare_record (in /usr/bin/coap-client)
==8967==    by 0x41FFD8: dtls_send_multi (in /usr/bin/coap-client)
==8967==    by 0x41FEDC: dtls_send_handshake_msg_hash (in /usr/bin/coap-client)
==8967==    by 0x41FF3D: dtls_send_handshake_msg (in /usr/bin/coap-client)
==8967==    by 0x421F43: dtls_send_finished (in /usr/bin/coap-client)
==8967==    by 0x42311E: check_server_hellodone (in /usr/bin/coap-client)
==8967==  Uninitialised value was created by a stack allocation
==8967==    at 0x421984: dtls_send_client_key_exchange (in /usr/bin/coap-client)
==8967==

Signed-off-by: Jon Shallow <supjps-libcoap@jpshallow.com>