### PR TITLE
Separate out rijndael.c into primary and wrapper functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ doc/Doxyfile
 doc/doxygen.out
 doc/html/
 libtinydtls.a
+libtinydtls.so
 tests/ccm-test
 tests/dtls-client
 tests/dtls-server

--- a/Makefile.in
+++ b/Makefile.in
@@ -39,7 +39,7 @@ install := cp
 
 # files and flags
 SOURCES:= dtls.c crypto.c ccm.c hmac.c netq.c peer.c dtls_time.c session.c dtls_debug.c dtls_prng.c
-SUB_OBJECTS:=aes/rijndael.o @OPT_OBJS@
+SUB_OBJECTS:=aes/rijndael.o aes/rijndael_wrap.o @OPT_OBJS@
 OBJECTS:= $(patsubst %.c, %.o, $(SOURCES)) $(SUB_OBJECTS)
 HEADERS:=dtls.h hmac.h dtls_debug.h dtls_config.h uthash.h numeric.h crypto.h global.h ccm.h \
  netq.h alert.h utlist.h dtls_prng.h peer.h state.h dtls_time.h session.h \

--- a/Makefile.tinydtls
+++ b/Makefile.tinydtls
@@ -1,7 +1,7 @@
 # This is a -*- Makefile -*-
 
 CFLAGS += -DDTLSv12 -DWITH_SHA256
-tinydtls_src = dtls.c crypto.c hmac.c rijndael.c sha2.c ccm.c netq.c ecc.c dtls_time.c peer.c session.c dtls_prng.c
+tinydtls_src = dtls.c crypto.c hmac.c rijndael.c rijndael_wrap.c sha2.c ccm.c netq.c ecc.c dtls_time.c peer.c session.c dtls_prng.c
 
 # This activates debugging support
 # CFLAGS += -DNDEBUG

--- a/aes/Makefile.in
+++ b/aes/Makefile.in
@@ -26,7 +26,7 @@ abs_builddir = @abs_builddir@
 top_builddir = @top_builddir@
 top_srcdir:= @top_srcdir@
 
-SOURCES:= rijndael.c
+SOURCES:= rijndael.c rijndael_wrap.c
 HEADERS:= rijndael.h
 OBJECTS:= $(patsubst %.c, %.o, $(SOURCES))
 CPPFLAGS=@CPPFLAGS@

--- a/aes/Makefile.riot
+++ b/aes/Makefile.riot
@@ -1,5 +1,5 @@
 MODULE := tinydtls_aes
 
-SRC := rijndael.c
+SRC := rijndael.c rijndael_wrap.c
 
 include $(RIOTBASE)/Makefile.base

--- a/aes/rijndael.h
+++ b/aes/rijndael.h
@@ -62,5 +62,8 @@ void	 rijndael_encrypt(rijndael_ctx *, const u_char *, u_char *);
 int	rijndaelKeySetupEnc(aes_u32 rk[/*4*(Nr + 1)*/], const aes_u8 cipherKey[], int keyBits);
 int	rijndaelKeySetupDec(aes_u32 rk[/*4*(Nr + 1)*/], const aes_u8 cipherKey[], int keyBits);
 void	rijndaelEncrypt(const aes_u32 rk[/*4*(Nr + 1)*/], int Nr, const aes_u8 pt[16], aes_u8 ct[16]);
+#ifdef WITH_AES_DECRYPT
+void	rijndaelDecrypt(const aes_u32 rk[/*4*(Nr + 1)*/], int Nr, const aes_u8 ct[16], aes_u8 pt[16]);
+#endif
 
 #endif /* __RIJNDAEL_H */

--- a/aes/rijndael_wrap.c
+++ b/aes/rijndael_wrap.c
@@ -1,0 +1,69 @@
+/*******************************************************************************
+ *
+ * Copyright (c) 2019 Olaf Bergmann (TZI) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *    Olaf Bergmann  - initial API and implementation
+ *    Jon Shallow    - split out wrapper code to support external rijndael code
+ *
+ *
+ *******************************************************************************/
+
+#include "rijndael.h"
+
+/* setup key context for encryption only */
+int
+rijndael_set_key_enc_only(rijndael_ctx *ctx, const u_char *key, int bits)
+{
+	int rounds;
+
+	rounds = rijndaelKeySetupEnc(ctx->ek, key, bits);
+	if (rounds == 0)
+		return -1;
+
+	ctx->Nr = rounds;
+#ifdef WITH_AES_DECRYPT
+	ctx->enc_only = 1;
+#endif
+
+	return 0;
+}
+
+#ifdef WITH_AES_DECRYPT
+/* setup key context for both encryption and decryption */
+int
+rijndael_set_key(rijndael_ctx *ctx, const u_char *key, int bits)
+{
+	int rounds;
+
+	rounds = rijndaelKeySetupEnc(ctx->ek, key, bits);
+	if (rounds == 0)
+		return -1;
+	if (rijndaelKeySetupDec(ctx->dk, key, bits) != rounds)
+		return -1;
+
+	ctx->Nr = rounds;
+	ctx->enc_only = 0;
+
+	return 0;
+}
+
+void
+rijndael_decrypt(rijndael_ctx *ctx, const u_char *src, u_char *dst)
+{
+	rijndaelDecrypt(ctx->dk, ctx->Nr, src, dst);
+}
+#endif
+
+void
+rijndael_encrypt(rijndael_ctx *ctx, const u_char *src, u_char *dst)
+{
+	rijndaelEncrypt(ctx->ek, ctx->Nr, src, dst);
+}


### PR DESCRIPTION
Some platforms already provide the primary rijndael functions, but do not
have the specific TinyDTLS wrapper functions.

This change is to split out the primary (i.e. common) rijndael functions
(leave in rijndael.c) and the TinyDTLS wrapper functions (put into
rijndael_wrap.c) and removing the appropriate #ifdef DTLS_EXT_RIJNDAEL.

.gitignore:

Ignore .so library file

Makefile.in:
Makefile.tinydtls:
aes/Makefile.in:
aes/Makefile.riot:

Add in rijndael_wrap.[co] as appropriate.

aes/rijndael.c:

Remove the wrapper functions.

aes/rijndael_wrap.c: (New)

Add in the wrapper functions.

Signed-off-by: Jon Shallow <supjps-libcoap@jpshallow.com>