### PR TITLE
use getrandom in place of srand on Linux

### DIFF
--- a/prng.h
+++ b/prng.h
@@ -32,6 +32,7 @@
 
 #ifndef WITH_CONTIKI
 #include <stdlib.h>
+#include <sys/random.h>
 
 /**
  * Fills \p buf with \p len random bytes. This is the default
@@ -40,14 +41,13 @@
  */
 static inline int
 dtls_prng(unsigned char *buf, size_t len) {
-  while (len--)
-    *buf++ = rand() & 0xFF;
+  getrandom(buf, len, 0);
   return 1;
 }
 
 static inline void
 dtls_prng_init(unsigned short seed) {
-	srand(seed);
+  // nothing to do on linux
 }
 #else /* WITH_CONTIKI */
 #include <string.h>


### PR DESCRIPTION
rand() and srand() are not appropriate for use in cryptography
getrandom() is, c.f. man pages

Signed-off-by: Julien Vermillard <jvermillard@sierrawireless.com>