### PR TITLE
Set bigger DTLS_MAX_BUF for Contiki/RIOT

### DIFF
--- a/global.h
+++ b/global.h
@@ -50,7 +50,7 @@ typedef unsigned char uint48[6];
 #ifdef DTLS_ECC
 #define DTLS_MAX_BUF 200
 #else /* DTLS_ECC */
-#define DTLS_MAX_BUF 100
+#define DTLS_MAX_BUF 120
 #endif /* DTLS_ECC */
 #else /* WITH_CONTIKI */
 #define DTLS_MAX_BUF 1400


### PR DESCRIPTION
This PR fixes the behavior of a server in RIOT built with only PSK support when an ECC client sends a second ClientHello to it.

## Problem

The server does not return `handshake_failure` as described in the [4th paragraph Section 7.4.1.2 of TLS 1.2 RFC](https://tools.ietf.org/html/rfc5246#section-7.4.1.2) because receiving buffer has a size of `DTLS_MAX_BUF` which is too small to receive a ClientHello from an ECC client.

## Testing

A step-by-step guide reproducing this issue on RIOT is described in RIOT-OS/RIOT#12351. I tested by applying this patch after commit dcac93 which is the current version used in RIOT.

I cannot test this with the latest develop because there is error when using latest commit on develop on RIOT but I don't think it is related to this PR.