### PR TITLE
dtls.c: fix error during handshake

### DIFF
--- a/dtls.c
+++ b/dtls.c
@@ -384,7 +384,7 @@ dtls_create_cookie(dtls_context_t *ctx,
     return dtls_alert_fatal_create(DTLS_ALERT_HANDSHAKE_FAILURE);
 
   fragment_length = dtls_get_fragment_length(DTLS_HANDSHAKE_HEADER(msg));
-  if ((fragment_length < e) || (e + DTLS_HS_LENGTH + fragment_length) > msglen)
+  if ((fragment_length < e) || ((DTLS_HS_LENGTH + fragment_length) > msglen))
     return dtls_alert_fatal_create(DTLS_ALERT_HANDSHAKE_FAILURE);
 
   dtls_hmac_update(&hmac_context,

--- a/dtls.c
+++ b/dtls.c
@@ -371,7 +371,8 @@ dtls_create_cookie(dtls_context_t *ctx,
   /* feed in the beginning of the Client Hello up to and including the
      session id */
   e = sizeof(dtls_client_hello_t);
-  e += (*(msg + DTLS_HS_LENGTH + e) & 0xff) + sizeof(uint8);
+  e += *(uint8_t *)(msg + DTLS_HS_LENGTH + e) & 0xff;
+  e += sizeof(uint8);
   if (e + DTLS_HS_LENGTH > msglen)
     return dtls_alert_fatal_create(DTLS_ALERT_HANDSHAKE_FAILURE);
 


### PR DESCRIPTION
This fixes the issues mentioned in #20, I bisected and found it was introduces by https://github.com/eclipse/tinydtls/commit/68a1cdaff9e329e13ea59529f1eb61b05632c297

It seems that the length check is not correct, this is fixed here and the RIOT example work again.

Rational: the length check `(e + DTLS_HS_LENGTH + fragment_length) > msglen)` is wrong because below (see `dtls_hmac_update`) length is passed as `fragment_length - e` hence
```
e + DTLS_HS_LENGTH + (fragment_length - e) = DTLS_HS_LENGTH + fragment_length
``` 

Hope this makes sense. 

I also piggy-backed a minor code cleanup to make style consistent.