### PR TITLE
add --disable-shared option

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -52,7 +52,10 @@ DISTDIR=$(top_builddir)/$(package)
 FILES:=Makefile.in configure configure.ac dtls_config.h.in \
   Makefile.tinydtls $(SOURCES) $(HEADERS)
 LIB:=libtinydtls
-LIBS:=$(LIB).a $(LIB).so
+LIBS:=$(LIB).a
+ifeq ("@ENABLE_SHARED@", "1")
+LIBS:=$(LIBS) $(LIB).so
+endif
 LDFLAGS:=@LDFLAGS@ @LIBS@
 ARFLAGS:=cru
 doc:=doc

--- a/configure.ac
+++ b/configure.ac
@@ -98,6 +98,14 @@ fi
 
 AC_SUBST(have_cunit)
 
+AC_ARG_ENABLE(shared,
+  [AS_HELP_STRING([--disable-shared],[disable build of shared library])],
+  [],
+  [enable_shared=yes])
+if test "$enable_shared" = "yes" ; then
+  ENABLE_SHARED=1
+fi
+
 CPPFLAGS="${CPPFLAGS} -DDTLSv12 -DWITH_SHA256"
 OPT_OBJS="${OPT_OBJS} sha2/sha2.o"
 
@@ -105,6 +113,7 @@ AC_SUBST(OPT_OBJS)
 AC_SUBST(NDEBUG)
 AC_SUBST(DTLS_ECC)
 AC_SUBST(DTLS_PSK)
+AC_SUBST(ENABLE_SHARED)
 AC_SUBST(AR)
 
 # Checks for header files.


### PR DESCRIPTION
Allow the user to disable shared library through --disable-shared.
Indeed, building of shared libraries is not supported by all toolchains
especially embedded ones

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>