### PR TITLE
dtls.h: Remove readbuf from dtls_context_t as it is unused

### DIFF
--- a/dtls.h
+++ b/dtls.h
@@ -226,8 +226,6 @@ typedef struct dtls_context_t {
   void *app;			/**< application-specific data */
 
   dtls_handler_t *h;		/**< callback handlers */
-
-  unsigned char readbuf[DTLS_MAX_BUF];
 } dtls_context_t;
 
 /** 


### PR DESCRIPTION
This allows RAM to be freed up.

Signed-off-by: Jon Shallow supjps-libcoap@jpshallow.com