### PR TITLE
crypto.c: Fix L used for nonce sizes

### DIFF
--- a/crypto.c
+++ b/crypto.c
@@ -581,8 +581,8 @@ dtls_encrypt(const unsigned char *src, size_t length,
 	     const unsigned char *aad, size_t la)
 {
   /* For backwards-compatibility, dtls_encrypt_params is called with
-   * M=8 and L=2. */
-  const dtls_ccm_params_t params = { nonce, 8, 2 };
+   * M=8 and L=3. */
+  const dtls_ccm_params_t params = { nonce, 8, 3 };
 
   return dtls_encrypt_params(&params, src, length, buf, key, keylen, aad, la);
 }
@@ -623,8 +623,8 @@ dtls_decrypt(const unsigned char *src, size_t length,
 	     const unsigned char *aad, size_t la)
 {
   /* For backwards-compatibility, dtls_encrypt_params is called with
-   * M=8 and L=2. */
-  const dtls_ccm_params_t params = { nonce, 8, 2 };
+   * M=8 and L=3. */
+  const dtls_ccm_params_t params = { nonce, 8, 3 };
 
   return dtls_decrypt_params(&params, src, length, buf, key, keylen, aad, la);
 }


### PR DESCRIPTION
Fix L sizes broken by cbe1810f8c123b1b458dbb7f06acb5e02414edf3 reworking.

Signed-off-by: Jon Shallow <supjps-libcoap@jpshallow.com>