### PR TITLE
sha2/sha2.c: fix build on big endian

### DIFF
--- a/sha2/sha2.c
+++ b/sha2/sha2.c
@@ -115,6 +115,33 @@
 #endif
 
 /*
+ * Macros for copying blocks of memory and for zeroing out ranges
+ * of memory.  Using these macros makes it easy to switch from
+ * using memset()/memcpy() and using bzero()/bcopy().
+ *
+ * Please define either SHA2_USE_MEMSET_MEMCPY or define
+ * SHA2_USE_BZERO_BCOPY depending on which function set you
+ * choose to use:
+ */
+#if !defined(SHA2_USE_MEMSET_MEMCPY) && !defined(SHA2_USE_BZERO_BCOPY)
+/* Default to memset()/memcpy() if no option is specified */
+#define	SHA2_USE_MEMSET_MEMCPY	1
+#endif
+#if defined(SHA2_USE_MEMSET_MEMCPY) && defined(SHA2_USE_BZERO_BCOPY)
+/* Abort with an error if BOTH options are defined */
+#error Define either SHA2_USE_MEMSET_MEMCPY or SHA2_USE_BZERO_BCOPY, not both!
+#endif
+
+#ifdef SHA2_USE_MEMSET_MEMCPY
+#define MEMSET_BZERO(p,l)	memset((p), 0, (l))
+#define MEMCPY_BCOPY(d,s,l)	memcpy((d), (s), (l))
+#endif
+#ifdef SHA2_USE_BZERO_BCOPY
+#define MEMSET_BZERO(p,l)	bzero((p), (l))
+#define MEMCPY_BCOPY(d,s,l)	bcopy((s), (d), (l))
+#endif
+
+/*
  * Define the followingsha2_* types to types of the correct length on
  * the native archtecture.   Most BSD systems and Linux define u_intXX_t
  * types.  Machines with very recent ANSI C headers, can use the
@@ -174,7 +201,7 @@ static inline void put32be(sha2_byte* data, sha2_word32 val)
 	data[1] = val; val >>= 8;
 	data[0] = val;
 #else /* BYTE_ORDER != LITTLE_ENDIAN */
-	MEMCPY_BCOPY(data, &val, sizeof(tmp));
+	MEMCPY_BCOPY(data, &val, sizeof(val));
 #endif /* BYTE_ORDER != LITTLE_ENDIAN */
 }
 
@@ -209,7 +236,7 @@ static inline void put64be(sha2_byte* data, sha2_word64 val)
 	data[1] = val; val >>= 8;
 	data[0] = val;
 #else /* BYTE_ORDER != LITTLE_ENDIAN */
-	MEMCPY_BCOPY(data, &val, sizeof(tmp));
+	MEMCPY_BCOPY(data, &val, sizeof(val));
 #endif /* BYTE_ORDER != LITTLE_ENDIAN */
 }
 
@@ -224,33 +251,6 @@ static inline void put64be(sha2_byte* data, sha2_word64 val)
 		(w)[1]++; \
 	} \
 }
-
-/*
- * Macros for copying blocks of memory and for zeroing out ranges
- * of memory.  Using these macros makes it easy to switch from
- * using memset()/memcpy() and using bzero()/bcopy().
- *
- * Please define either SHA2_USE_MEMSET_MEMCPY or define
- * SHA2_USE_BZERO_BCOPY depending on which function set you
- * choose to use:
- */
-#if !defined(SHA2_USE_MEMSET_MEMCPY) && !defined(SHA2_USE_BZERO_BCOPY)
-/* Default to memset()/memcpy() if no option is specified */
-#define	SHA2_USE_MEMSET_MEMCPY	1
-#endif
-#if defined(SHA2_USE_MEMSET_MEMCPY) && defined(SHA2_USE_BZERO_BCOPY)
-/* Abort with an error if BOTH options are defined */
-#error Define either SHA2_USE_MEMSET_MEMCPY or SHA2_USE_BZERO_BCOPY, not both!
-#endif
-
-#ifdef SHA2_USE_MEMSET_MEMCPY
-#define MEMSET_BZERO(p,l)	memset((p), 0, (l))
-#define MEMCPY_BCOPY(d,s,l)	memcpy((d), (s), (l))
-#endif
-#ifdef SHA2_USE_BZERO_BCOPY
-#define MEMSET_BZERO(p,l)	bzero((p), (l))
-#define MEMCPY_BCOPY(d,s,l)	bcopy((s), (d), (l))
-#endif
 
 
 /*** THE SIX LOGICAL FUNCTIONS ****************************************/


### PR DESCRIPTION
Build is broken since 865ec9ba1d44e629c1107c299aebd20e901a19ff because tmp is undefined in put32be and put64be:

```
/home/buildroot/autobuild/instance-1/output-1/host/bin/m68k-linux-gcc -DSHA2_USE_INTTYPES_H -Wall -std=c99 -pedantic -fPIC -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 -DDTLSv12 -DWITH_SHA256 -I..  -c -o sha2.o sha2.c
sha2.c: In function 'get32be':
sha2.c:164:2: warning: implicit declaration of function 'MEMCPY_BCOPY' [-Wimplicit-function-declaration]
  MEMCPY_BCOPY(&tmp, data, sizeof(tmp));
  ^~~~~~~~~~~~
sha2.c: In function 'put32be':
sha2.c:177:34: error: 'tmp' undeclared (first use in this function)
  MEMCPY_BCOPY(data, &val, sizeof(tmp));
                                  ^~~
```
Fix this error by replacing tmp by val

Moreover, move MEMCPY_BCOPY before its usage or linking step will fail

Fixes:
 - http://autobuild.buildroot.org/results/e8704e02fdede7b63e22da552292977b23380b32

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>