### PR TITLE
dtls.c: Fix size of buffer for dtls_send_certificate_ecdsa()

### DIFF
--- a/dtls.c
+++ b/dtls.c
@@ -115,7 +115,6 @@ memarray_t dtlscontext_storage;
 #define DTLS_CH_LENGTH_MAX sizeof(dtls_client_hello_t) + DTLS_COOKIE_LENGTH_MAX + 12 + 26
 #define DTLS_HV_LENGTH sizeof(dtls_hello_verify_t)
 #define DTLS_SH_LENGTH (2 + DTLS_RANDOM_LENGTH + 1 + 2 + 1)
-#define DTLS_CE_LENGTH (3 + 3 + 27 + DTLS_EC_KEY_SIZE + DTLS_EC_KEY_SIZE)
 #define DTLS_SKEXEC_LENGTH (1 + 2 + 1 + 1 + DTLS_EC_KEY_SIZE + DTLS_EC_KEY_SIZE + 1 + 1 + 2 + 70)
 #define DTLS_SKEXECPSK_LENGTH_MIN 2
 #define DTLS_SKEXECPSK_LENGTH_MAX 2 + DTLS_PSK_MAX_CLIENT_IDENTITY_LEN
@@ -2016,7 +2015,7 @@ static int
 dtls_send_certificate_ecdsa(dtls_context_t *ctx, dtls_peer_t *peer,
 			    const dtls_ecdsa_key_t *key)
 {
-  uint8 buf[DTLS_CE_LENGTH];
+  uint8 buf[sizeof(uint24) + DTLS_EC_SUBJECTPUBLICKEY_SIZE];
   uint8 *p;
 
   /* Certificate


### PR DESCRIPTION
As per #32 DTLS_CE_LENGTH evaluates to 97, but only 94 bytes are needed.

Remove DTLS_CE_LENGTH and define output buffer size for 
dtls_send_certificate_ecdsa() for clarity to be
  uint8 buf[sizeof(uint24) + DTLS_EC_SUBJECTPUBLICKEY_SIZE];

Signed-off-by: Jon Shallow <supjps-libcoap@jpshallow.com>