### PR TITLE
configure.ac: Fix CUNIT spurious bracket

### DIFF
--- a/README
+++ b/README
@@ -19,6 +19,11 @@ When using the code from the git repository at sourceforge, invoke
   $ autoheader
   $ ./configure
 
+or if there is an update to configure.ac
+
+  $ autoreconf --force --install
+  $ ./configure
+
 to re-create the configure script.
 
 ## Contiki

--- a/configure.ac
+++ b/configure.ac
@@ -92,7 +92,7 @@ if test "x$build_tests" = "xyes"; then
     PKG_CHECK_MODULES([CUNIT],
                       [cunit],
                       [have_cunit=yes
-                       AC_DEFINE(HAVE_LIBCUNIT, [1], [Define if the system has libcunit])]
+                       AC_DEFINE(HAVE_LIBCUNIT, [1], [Define if the system has libcunit])
                        AC_DEFINE(TEST_INCLUDE, [1], [Define to include test wrappers for static functions])],
                       [have_cunit=no])
 fi


### PR DESCRIPTION
configure.ac:
Remove spurious ] from the CUNIT test

README:

Include autoreconf to handle configure.ac updates.

Signed-off-by: Jon Shallow <supjps-libcoap@jpshallow.com>