### PR TITLE
dtls_contiki-ng: add support to contiki-ng

### DIFF
--- a/dtls.c
+++ b/dtls.c
@@ -19,7 +19,9 @@
 
 #include "tinydtls.h"
 #include "dtls_time.h"
-
+#ifdef WITH_CONTIKI
+#include "dtls-support.h"
+#endif /* WITH_CONTIKI */
 #include <stdio.h>
 #include <stdlib.h>
 #ifdef HAVE_ASSERT_H
@@ -365,9 +367,15 @@ dtls_create_cookie(dtls_context_t *ctx,
   dtls_hmac_context_t hmac_context;
   dtls_hmac_init(&hmac_context, ctx->cookie_secret, DTLS_COOKIE_SECRET_LENGTH);
 
+  #ifdef WITH_CONTIKI
+  dtls_hmac_update(&hmac_context,
+		   (unsigned char *)dtls_session_get_address(session),
+        dtls_session_get_address_size(session));
+  #else /* WITH_CONTIKI */
   dtls_hmac_update(&hmac_context,
 		   (unsigned char *)&session->addr, session->size);
 
+  #endif /* WITH_CONTIKI */
   /* feed in the beginning of the Client Hello up to and including the
      session id */
   e = DTLS_CH_LENGTH;
@@ -3853,7 +3861,7 @@ handle_alert(dtls_context_t *ctx, dtls_peer_t *peer,
 #ifdef WITH_CONTIKI
 #ifndef NDEBUG
     PRINTF("removed peer [");
-    PRINT6ADDR(&peer->session.addr);
+    PRINT6ADDR(dtls_session_get_address(&peer->session));
     PRINTF("]:%d\n", uip_ntohs(peer->session.port));
 #endif
 #endif /* WITH_CONTIKI */

--- a/dtls_debug.c
+++ b/dtls_debug.c
@@ -171,10 +171,10 @@ dsrv_print_addr(const session_t *addr, char *buf, size_t len) {
     if (i) {
       *p++ = ':';
     }
-    *p++ = hex[(addr->addr.u8[i] & 0xf0) >> 4];
-    *p++ = hex[(addr->addr.u8[i] & 0x0f)];
-    *p++ = hex[(addr->addr.u8[i+1] & 0xf0) >> 4];
-    *p++ = hex[(addr->addr.u8[i+1] & 0x0f)];
+    *p++ = hex[(addr->ipaddr.u8[i] & 0xf0) >> 4];
+    *p++ = hex[(addr->ipaddr.u8[i] & 0x0f)];
+    *p++ = hex[(addr->ipaddr.u8[i+1] & 0xf0) >> 4];
+    *p++ = hex[(addr->ipaddr.u8[i+1] & 0x0f)];
   }
   *p++ = ']';
 #else /* NETSTACK_CONF_IPV6 */

--- a/dtls_debug.h
+++ b/dtls_debug.h
@@ -28,7 +28,7 @@
 # ifndef DEBUG
 #  define DEBUG DEBUG_PRINT
 # endif /* DEBUG */
-#include "net/ip/uip-debug.h"
+#include "uip-debug.h"
 
 #ifdef CONTIKI_TARGET_MBXXX
 extern char __Stack_Init, _estack;

--- a/ecc/testecc.c
+++ b/ecc/testecc.c
@@ -115,6 +115,8 @@ static const uint32_t ecdsaTestRand2[] = { 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0
 static const uint32_t ecdsaTestresultR2[] = { 0x14146C91, 0xE878724D, 0xCD4FF928, 0xCC24BC04, 0xAC403390, 0x650C0060, 0x4A30B3F1, 0x9C69B726};
 static const uint32_t ecdsaTestresultS2[] = { 0x433AAB6F, 0x808250B1, 0xE46F90F4, 0xB342E972, 0x18B2F7E4, 0x2DB981A2, 0x6A288FA4, 0x41CF59DB};
 
+#ifdef TEST_INCLUDE
+
 void addTest(){
 	uint32_t tempx[8];
 	uint32_t tempy[8];
@@ -224,3 +226,4 @@ int main(int argc, char const *argv[])
 	return 0;
 }
 #endif /* CONTIKI */
+#endif /*TEST_INCLUDE*/

--- a/ecc/testfield.c
+++ b/ecc/testfield.c
@@ -106,6 +106,8 @@ void nullEverything(){
 	memset(temp2, 0, sizeof(temp));
 }
 
+#ifdef TEST_INCLUDE
+
 void fieldAddTest(){
 	assert(ecc_isSame(one, one, arrayLength));
 	ecc_fieldAdd(one, null, ecc_prime_r, temp);
@@ -288,3 +290,4 @@ int main(int argc, char const *argv[])
 	return 0;
 }
 #endif /* CONTIKI */
+#endif /*TEST_INCLUDE*/

--- a/session.c
+++ b/session.c
@@ -68,7 +68,9 @@ void
 dtls_session_init(session_t *sess) {
   assert(sess);
   memset(sess, 0, sizeof(session_t));
-  sess->size = sizeof(sess->addr);
+  #ifndef WITH_CONTIKI
+    sess->size = sizeof(sess->addr);
+  #endif
 }
 
 /* These functions are primarly needed for the tinydtls ruby gem.
@@ -117,8 +119,10 @@ dtls_session_addr(session_t *sess, socklen_t *addrlen) {
 }
 #endif /* !(defined (WITH_CONTIKI)) && !(defined (RIOT_VERSION)) */
 
+#ifndef WITH_CONTIKI
 int
 dtls_session_equals(const session_t *a, const session_t *b) {
   assert(a); assert(b);
   return _dtls_address_equals_impl(a, b);
-}
+} 
+#endif

--- a/session.h
+++ b/session.h
@@ -23,13 +23,18 @@
 #include "global.h"
 
 #ifdef WITH_CONTIKI
-#include "ip/uip.h"
+#ifdef BUILD_WITH_COAP
+#include "coap-endpoint.h"
+typedef coap_endpoint_t session_t;
+#else /*BUILD_WITH_COAP*/
+#include "uip.h"
 typedef struct {
   unsigned char size;
-  uip_ipaddr_t addr;
+  uip_ipaddr_t ipaddr;
   unsigned short port;
   int ifindex;
 } session_t;
+#endif /*BUILD_WITH_COAP*/
  /* TODO: Add support for RIOT over sockets  */
 #elif defined(WITH_RIOT_GNRC)
 #include "net/ipv6/addr.h"

--- a/sha2/sha2prog.c
+++ b/sha2/sha2prog.c
@@ -54,14 +54,20 @@ int main(int argc, char **argv) {
 	int		quiet = 0, hash = 0;
 	char		*av, *file = (char*)0;
 	FILE		*IN = (FILE*)0;
-	dtls_sha256_ctx	ctx256;
-	dtls_sha384_ctx	ctx384;
-	dtls_sha512_ctx	ctx512;
-	unsigned char	buf[BUFLEN];
+	char	buf[BUFLEN];
 
+	#ifdef WITH_SHA256
+	dtls_sha256_ctx	ctx256;
 	dtls_sha256_init(&ctx256);
+	#endif /*WITH_SHA256*/
+	#ifdef WITH_SHA384
+	dtls_sha384_ctx	ctx384;
 	dtls_sha384_init(&ctx384);
+	#endif /*WITH_SHA384*/
+	#ifdef WITH_SHA512
+	dtls_sha512_ctx	ctx512;
 	dtls_sha512_init(&ctx512);
+	#endif /*WITH_SHA512*/
 
 	/* Read data from STDIN by default */
 	fd = fileno(stdin);
@@ -102,31 +108,43 @@ int main(int argc, char **argv) {
 	kl = 0;
 	while ((l = read(fd,buf,BUFLEN)) > 0) {
 		kl += l;
+		#ifdef WITH_SHA256
 		dtls_sha256_update(&ctx256, (unsigned char*)buf, l);
+		#endif /*WITH_SHA256*/
+		#ifdef WITH_SHA384
 		dtls_sha384_update(&ctx384, (unsigned char*)buf, l);
+		#endif /*WITH_SHA384*/
+		#ifdef WITH_SHA512
 		dtls_sha512_update(&ctx512, (unsigned char*)buf, l);
+		#endif /*WITH_SHA512*/
 	}
 	if (file) {
 		fclose(IN);
 	}
 
 	if (hash & 1) {
+		#ifdef WITH_SHA256
 		dtls_sha256_end(&ctx256, buf);
 		if (!quiet)
 			printf("SHA-256 (%s) = ", file);
 		printf("%s\n", buf);
+		#endif /*WITH_SHA256*/
 	}
 	if (hash & 2) {
+		#ifdef WITH_SHA384
 		dtls_sha384_end(&ctx384, buf);
 		if (!quiet)
 			printf("SHA-384 (%s) = ", file);
 		printf("%s\n", buf);
+		#endif /*WITH_SHA384*/
 	}
 	if (hash & 4) {
+		#ifdef WITH_SHA512
 		dtls_sha512_end(&ctx512, buf);
 		if (!quiet)
 			printf("SHA-512 (%s) = ", file);
 		printf("%s\n", buf);
+		#endif /*WITH_SHA512*/
 	}
 
 	return 1;

--- a/sha2/sha2speed.c
+++ b/sha2/sha2speed.c
@@ -60,9 +60,15 @@ void printspeed(char *caption, unsigned long bytes, double time) {
 
 
 int main(int argc, char **argv) {
+	#ifdef WITH_SHA256
 	dtls_sha256_ctx	c256;
+	#endif /*WITH_SHA256*/
+	#ifdef WITH_SHA384
 	dtls_sha384_ctx	c384;
+	#endif /*WITH_SHA384*/
+	#ifdef WITH_SHA512
 	dtls_sha512_ctx	c512;
+	#endif /*WITH_SHA512*/
 	char		buf[BUFSIZE];
 	char		md[DTLS_SHA512_DIGEST_STRING_LENGTH];
 	int		bytes, blocks, rep, i, j;
@@ -97,9 +103,8 @@ int main(int argc, char **argv) {
 	ave256 = ave384 = ave512 = 0;
 	best256 = best384 = best512 = 100000;
 	for (i = 0; i < rep; i++) {
+		#ifdef WITH_SHA256
 		dtls_sha256_init(&c256);
-		dtls_sha384_init(&c384);
-		dtls_sha512_init(&c512);
 	
 		gettimeofday(&start, (struct timezone*)0);
 		for (j = 0; j < blocks; j++) {
@@ -116,7 +121,10 @@ int main(int argc, char **argv) {
 			best256 = t;
 		}
 		printf("SHA-256[%d] (%.4f/%.4f/%.4f seconds) = 0x%s\n", i+1, t, ave256/(i+1), best256, md);
-
+		#endif /*WITH_SHA256*/
+		#ifdef WITH_SHA384
+		dtls_sha384_init(&c384);
+		
 		gettimeofday(&start, (struct timezone*)0);
 		for (j = 0; j < blocks; j++) {
 			dtls_sha384_update(&c384, (unsigned char*)buf, BUFSIZE);
@@ -132,6 +140,9 @@ int main(int argc, char **argv) {
 			best384 = t;
 		}
 		printf("SHA-384[%d] (%.4f/%.4f/%.4f seconds) = 0x%s\n", i+1, t, ave384/(i+1), best384, md);
+		#endif /*WITH_SHA384*/
+		#ifdef WITH_SHA512
+		dtls_sha512_init(&c512);
 
 		gettimeofday(&start, (struct timezone*)0);
 		for (j = 0; j < blocks; j++) {
@@ -148,6 +159,7 @@ int main(int argc, char **argv) {
 			best512 = t;
 		}
 		printf("SHA-512[%d] (%.4f/%.4f/%.4f seconds) = 0x%s\n", i+1, t, ave512/(i+1), best512, md);
+		#endif	/*WITH_SHA512*/
 	}
 	ave256 /= rep;
 	ave384 /= rep;

--- a/tinydtls.h
+++ b/tinydtls.h
@@ -30,6 +30,7 @@
 
 #ifdef CONTIKI
 #include "platform-specific/platform.h"
+#include "dtls-support-conf.h"
 #endif /* CONTIKI */
 
 #ifndef CONTIKI


### PR DESCRIPTION
Minor changes to add support as a submodule of contiki-ng.

Currently contiki-ng is using an outdated standalone version of tinydtls as a submodule, which causes problems that have already been resolved in the develop branch, such as (https://github.com/obgm/libcoap/issues/160).

These changes will allow the development branch to be used as a submodule of contiki-ng.

Signed-off-by: lutgaru lutgaru@gmail.com