### PR TITLE
sha256: Handle r and s values that do not use 32 bytes

### DIFF
--- a/crypto.h
+++ b/crypto.h
@@ -414,7 +414,7 @@ int dtls_ecdsa_verify_sig(const unsigned char *pub_key_x,
 			  const unsigned char *keyx_params, size_t keyx_params_size,
 			  unsigned char *result_r, unsigned char *result_s);
 
-int dtls_ec_key_from_uint32_asn1(const uint32_t *key, size_t key_size,
+int dtls_ec_key_asn1_from_uint32(const uint32_t *key, size_t key_size,
 				 unsigned char *buf);
 
 


### PR DESCRIPTION
In ASN.1, these are positive signed integer values, big-endian encoded.

There is an additional 0x00 prefix if the number has the signed bit set, so
that the number remains positive - hence length can be > 32.

If the leading bits are 0, and there is more than 8 of them, then the leading
0x00 byte(s) can be dropped - hence length can be < 32.

This fix allows the dtls_check_ecdsa_signature_elem() to work correctly.

Signed-off-by: Jon Shallow <supjps-libcoap@jpshallow.com>