### PR TITLE
[ECC] ecc.c: fix build with -Werror=sign-compare

### DIFF
--- a/ecc/ecc.c
+++ b/ecc/ecc.c
@@ -310,8 +310,8 @@ static void fieldModO(const uint32_t *A, uint32_t *result, uint8_t length) {
  * @return 1 if all elements in @val are zero, 0 otherwise.
  */
 static int is_zero(const uint32_t* val, size_t count) {
-  int result = 0;
-  int idx;
+  unsigned result = 0;
+  unsigned idx;
 
   for (idx = 0; idx < count; idx++) {
     result += val[idx] == 0;


### PR DESCRIPTION
`count` is unsigned while `result` and `idx` are both signed.
This causes a build failure with `-Werror`.

Since both variables can never assume negative values, just make them `unsisgned` as well.