### PR TITLE
dtls.c: Destroy peer on generation of fatal alert during handshake

### DIFF
--- a/dtls.c
+++ b/dtls.c
@@ -4186,7 +4186,15 @@ dtls_handle_message(dtls_context_t *ctx,
       if (err < 0) {
 	dtls_warn("error while handling handshake packet\n");
 	dtls_alert_send_from_err(ctx, peer, session, err);
-	return err;
+
+        if (DTLS_ALERT_LEVEL_FATAL == ((-err) & 0xff00) >> 8) {
+          /* invalidate peer */
+          peer->state = DTLS_STATE_CLOSED;
+          dtls_stop_retransmission(ctx, peer);
+          dtls_destroy_peer(ctx, peer, 1);
+          peer = NULL;
+        }
+        return err;
       }
       if (peer && peer->state == DTLS_STATE_CONNECTED) {
 	/* stop retransmissions */


### PR DESCRIPTION
RFC 5246 7.2 Alert Protocol

   Alert messages
   with a level of fatal result in the immediate termination of the
   connection.

Signed-off-by: Jon Shallow <supjps-libcoap@jpshallow.com>