### PR TITLE
dtls.c: Check for duplicate optional handshake messages

### DIFF
--- a/peer.h
+++ b/peer.h
@@ -52,6 +52,8 @@ typedef struct dtls_peer_t {
 
   dtls_peer_type role;       /**< denotes if this host is DTLS_CLIENT or DTLS_SERVER */
   dtls_state_t state;        /**< DTLS engine state */
+  uint32_t serverkeyexchange:1;  /**< Seen optional ServerKeyExchange from Server */
+  uint32_t certificaterequest:1; /**< Seen optional CertificateRequest from Server */
 
   dtls_security_parameters_t *security_params[2];
   dtls_handshake_parameters_t *handshake_params;


### PR DESCRIPTION
In general the handshake state machine forces the handshakes to go through
a defined order, but duplicate optional CertificateRequest or ServerKeyExchange
handshakes are not detected.

This fix adds in tracking whether a CertificateRequest or ServerKeyExchange
have been received and rejects any duplication.

Signed-off-by: Jon Shallow <supjps-libcoap@jpshallow.com>