### PR TITLE
Add separate stateless processing for client_hello of epoch 0.

### DIFF
--- a/peer.h
+++ b/peer.h
@@ -57,6 +57,14 @@ typedef struct dtls_peer_t {
   dtls_handshake_parameters_t *handshake_params;
 } dtls_peer_t;
 
+/**
+ * Holds ClientHello's sequence numbers for the stateless address verification. */
+typedef struct dtls_ephemeral_peer_t {
+  session_t *session;         /**< peer address and local interface */
+  uint64_t rseq;             /**< ClientHello record sequence number */
+  uint16_t mseq;             /**< ClientHello handshake message sequence number */
+} dtls_ephemeral_peer_t;
+
 static inline dtls_security_parameters_t *dtls_security_params_epoch(dtls_peer_t *peer, uint16_t epoch)
 {
   if (peer->security_params[0] && peer->security_params[0]->epoch == epoch) {


### PR DESCRIPTION
The PR is on the top of some other pending ones.
If at all merged, it is intended to be merged after these PRs.

Use the record and message sequence numbers of that client_hellos for
either sending a hello verify request or starting the handshake on the
server side with sending a server_hello.

The function of a HELLO_REQUEST is unclear and therefore not considered.
In some scopes a HELLO_REQUEST is only used for associated peers to
trigger a rehandshake (handshake executed within an previous encrypted
association, epoch > 0), and some scopes seems to handle also
situations, where either no previous association is required or the new
handshake is executed in epoch 0. That may be clarified either before or
after this change.

Signed-off-by: Achim Kraus <achim.kraus@bosch.io> 