### PR TITLE
dtls.c: Fix check for peer

### DIFF
--- a/dtls.c
+++ b/dtls.c
@@ -4216,7 +4216,7 @@ dtls_handle_message(dtls_context_t *ctx,
 	dtls_warn("error while handling handshake packet\n");
 	dtls_alert_send_from_err(ctx, peer, session, err);
 
-        if (DTLS_ALERT_LEVEL_FATAL == ((-err) & 0xff00) >> 8) {
+        if (peer && DTLS_ALERT_LEVEL_FATAL == ((-err) & 0xff00) >> 8) {
           /* invalidate peer */
           peer->state = DTLS_STATE_CLOSED;
           dtls_stop_retransmission(ctx, peer);


### PR DESCRIPTION
Fix code updated by #87 to check for peer != NULL.

Signed-off-by: Jon Shallow <supjps-libcoap@jpshallow.com>