### PR TITLE
fix build with automake >= 1.16.4

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -29,7 +29,6 @@ test -e install-sh || touch install-sh
 AC_PROG_MAKE_SET
 AC_PROG_CC
 AC_PROG_RANLIB
-m4_ifdef([AM_PROG_AR], [AM_PROG_AR], [AR=ar])
 
 AC_C_BIGENDIAN
 


### PR DESCRIPTION
Drop call to `AM_PROG_AR` which will raise the following build failure with automake >= 1.16.4 because configure.ac doesn't call `AM_INIT_AUTOMAKE`:

`configure.ac: error: required file 'ar-lib' not found`

Adding a call to `AM_INIT_AUTOMAKE` will copy ar-lib file but will raise another build failure because tinydtls use hand-written `Makefile.in` instead of `Makefile.am`

Fixes:
 - http://autobuild.buildroot.org/results/c2fa1260cb4a2dbf2d7a90fea3ba99a389bcd470

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>