### PR TITLE
dtls.c: Check for optional handshake messages

### DIFF
--- a/dtls.c
+++ b/dtls.c
@@ -3628,7 +3628,8 @@ handle_handshake_msg(dtls_context_t *ctx, dtls_peer_t *peer, uint8 *data, size_t
 #ifdef DTLS_ECC
   case DTLS_HT_CERTIFICATE_REQUEST:
 
-    if (state != DTLS_STATE_WAIT_SERVERHELLODONE) {
+    if (state != DTLS_STATE_WAIT_SERVERHELLODONE ||
+        !is_tls_ecdhe_ecdsa_with_aes_128_ccm_8(peer->handshake_params->cipher)) {
       return dtls_alert_fatal_create(DTLS_ALERT_UNEXPECTED_MESSAGE);
     }
 

--- a/dtls.h
+++ b/dtls.h
@@ -348,6 +348,11 @@ typedef struct __attribute__((__packed__)) {
 #define DTLS_HT_CLIENT_KEY_EXCHANGE 16
 #define DTLS_HT_FINISHED            20
 
+/**
+ * Pseudo handshake message type, if no optional handshake message is expected.
+ */
+#define DTLS_HT_NO_OPTIONAL_MESSAGE        -1
+
 /** Header structure for the DTLS handshake protocol. */
 typedef struct __attribute__((__packed__)) {
   uint8 msg_type; /**< Type of handshake message  (one of DTLS_HT_) */

--- a/peer.h
+++ b/peer.h
@@ -52,6 +52,7 @@ typedef struct dtls_peer_t {
 
   dtls_peer_type role;       /**< denotes if this host is DTLS_CLIENT or DTLS_SERVER */
   dtls_state_t state;        /**< DTLS engine state */
+  int16_t optional_handshake_message; /**< optional next handshake message, DTLS_HT_NO_OPTIONAL_MESSAGE, if no optional message is expected. */
 
   dtls_security_parameters_t *security_params[2];
   dtls_handshake_parameters_t *handshake_params;


### PR DESCRIPTION
In general the handshake state machine forces the handshakes to go
through
a defined order. But optional handshake message are not controlled by
that.

This fix introduces a optional handshake message field. With that, the
state-machine is enabled to check, if this message is (optionally)
expected. When processed, the field is reset and receiving the optional
message twice will therefore fail the handshake.

Signed-off-by: Achim Kraus <achim.kraus@bosch.io>