### PR TITLE
dtls.c: fix retransmission of last flight.

### DIFF
--- a/dtls.c
+++ b/dtls.c
@@ -4306,10 +4306,10 @@ dtls_handle_message(dtls_context_t *ctx,
     switch (msg[0]) {
 
     case DTLS_CT_CHANGE_CIPHER_SPEC:
-      dtls_stop_retransmission(ctx, peer);
       err = handle_ccs(ctx, peer, msg, data, data_length);
       if (err < 0) {
         dtls_warn("error while handling ChangeCipherSpec message\n");
+        dtls_stop_retransmission(ctx, peer);
         dtls_alert_send_from_err(ctx, peer, err);
 
         /* invalidate peer */


### PR DESCRIPTION
The last dtls handshake flights are very special on both sides. The
server doesn't retransmit the last flight on it's own. The server only
retransmits the last flight, if the client's last flight is received
again.
Therefore it's important, that the client doesn't stop the
retransmission of the last flight just by receiving the server's
ChangeCipherSpec.
Fix it by moving the dtls_stop_retransmission into the error handling.

Signed-off-by: Achim Kraus <achim.kraus@bosch.io>