### PR TITLE
Add support for pkg-config in tinydtls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ tests/dtls-server
 tests/prf-test
 tinydtls-0.6.0
 ./tinydtls-0.6.0/
+tinydtls.pc
 TAGS
 *.patch
 .gitignore

--- a/Makefile.in
+++ b/Makefile.in
@@ -1,7 +1,7 @@
 # Makefile for tinydtls
 #
 #
-# Copyright (c) 2011-2020 Olaf Bergmann (TZI) and others.
+# Copyright (c) 2011-2021 Olaf Bergmann (TZI) and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # and Eclipse Distribution License v. 1.0 which accompanies this distribution.
@@ -12,6 +12,7 @@
 #
 # Contributors:
 #    Olaf Bergmann  - initial API and implementation
+#    Hugo Damer     - support for pkg-config
 #
 
 # the library's version
@@ -45,6 +46,7 @@ OBJECTS:= $(patsubst %.c, %.o, $(SOURCES)) $(SUB_OBJECTS)
 HEADERS:=dtls.h hmac.h dtls_debug.h dtls_config.h uthash.h numeric.h crypto.h global.h ccm.h \
  netq.h alert.h utlist.h dtls_prng.h peer.h state.h dtls_time.h session.h \
  tinydtls.h dtls_mutex.h
+PKG_CONFIG_FILES:=tinydtls.pc
 CFLAGS:=-Wall -pedantic -std=c99 -DSHA2_USE_INTTYPES_H @CFLAGS@ @WARNING_CFLAGS@
 CPPFLAGS:=@CPPFLAGS@ -DDTLS_CHECK_CONTENTTYPE -I$(top_srcdir)
 SUBDIRS:=tests tests/unit-tests doc platform-specific sha2 aes ecc
@@ -115,10 +117,11 @@ dist:	$(FILES) $(DISTSUBDIRS)
 	tar czf $(package).tar.gz $(DISTDIR)
 
 install:	$(LIBS) $(HEADERS) $(SUBDIRS)
-	test -d $(DESTDIR)$(libdir) || mkdir -p $(DESTDIR)$(libdir)
+	test -d $(DESTDIR)$(libdir)/pkgconfig/ || mkdir -p $(DESTDIR)$(libdir)/pkgconfig
 	test -d $(DESTDIR)$(includedir) || mkdir -p $(DESTDIR)$(includedir)
 	$(install) $(LIBS) $(DESTDIR)$(libdir)/
 	$(install) $(HEADERS) $(DESTDIR)$(includedir)/
+	$(install) $(PKG_CONFIG_FILES) $(DESTDIR)$(libdir)/pkgconfig/
 	for dir in $(SUBDIRS); do \
 		$(MAKE) -C $$dir install="$(install)" includedir=$(includedir) install; \
 	done

--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 #                                               -*- Autoconf -*-
 # Process this file with autoconf to produce a configure script.
 #
-# Copyright (c) 2011-2020 Olaf Bergmann (TZI) and others.
+# Copyright (c) 2011-2021 Olaf Bergmann (TZI) and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # and Eclipse Distribution License v. 1.0 which accompanies this distribution.
@@ -13,9 +13,10 @@
 # Contributors:
 #    Olaf Bergmann  - initial API and implementation
 #    Hauke Mehrtens - memory optimization, ECC integration
+#    Hugo Damer     - support for pkg-config
 
 AC_PREREQ([2.65])
-AC_INIT([tinydtls], [0.8.6])
+AC_INIT([tinydtls], [0.8.6], [], [], [https://projects.eclipse.org/projects/iot.tinydtls])
 AC_CONFIG_SRCDIR([dtls.c])
 dnl AC_CONFIG_HEADERS([config.h])
 
@@ -144,6 +145,7 @@ AC_CONFIG_FILES([Makefile
                  tests/Makefile
                  tests/unit-tests/Makefile
                  platform-specific/Makefile
+                 tinydtls.pc
 		 sha2/Makefile
 		 aes/Makefile
 		 ecc/Makefile])

--- a/tinydtls.pc.in
+++ b/tinydtls.pc.in
@@ -1,0 +1,26 @@
+# pkg-config file for tinydtls
+#
+#
+# Copyright (c) 2011-2021 Olaf Bergmann (TZI) and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# and Eclipse Distribution License v. 1.0 which accompanies this distribution.
+#
+# The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+# and the Eclipse Distribution License is available at
+# http://www.eclipse.org/org/documents/edl-v10.php.
+#
+# Contributors:
+#    Hugo Damer     - support for pkg-config in tinydtls
+
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+includedir=@includedir@
+libdir=@libdir@
+
+Name: @PACKAGE_NAME@
+Description: A C library for Datagram Transport Layer Security (DTLS) supporting both client and server functionality.
+URL: @PACKAGE_URL@
+Version: @PACKAGE_VERSION@
+Libs: -L${libdir} -ltinydtls
+Cflags: -I${includedir}/tinydtls


### PR DESCRIPTION
In some cases it might be advantageous to install tinydtls to some (system-wide) prefix (e.g. `/usr/local`) and use it from there.

Because the tinydtls headers require the header sub-directory (i.e. `/usr/local/include/tinydtls` if the prefix is `/usr/local`) to be in the header search path, software that uses tinydtls has to add `-I[HEADER_PATH]` to its compiler flags (as well as the `-L[LIB_PATH] -ltinydtls` linker flags if the prefix is not part of the standard library search path). 

By providing a pkg-config file, it is possible for build scripts in dependent projects to automatically set the appropiate compiler and linker flags for tinydtls without having to manually find the tinydtls subdirectory in one of its header search path entries.

The format of the pkg-config file follows the guide in https://people.freedesktop.org/~dbn/pkg-config-guide.html, with the same adjustments that were made in e.g. libcoap (https://github.com/obgm/libcoap/blob/develop/libcoap-3.pc.in) to allow for integration into autotools (e.g. setting the package name, URL and version based on the values specified in `AC_INIT`).

Signed-off-by: Hugo Hakim Damer \<hdamer@uni-bremen.de\>