### PR TITLE
dtls_time.h: conditionally include time header files.

### DIFF
--- a/dtls_time.h
+++ b/dtls_time.h
@@ -23,7 +23,10 @@
 #define _DTLS_DTLS_TIME_H_
 
 #include <stdint.h>
+
+#ifdef HAVE_SYS_TIME_H
 #include <sys/time.h>
+#endif /* HAVE_SYS_TIME_H */
 
 #include "tinydtls.h"
 
@@ -50,7 +53,9 @@
 typedef uint64_t clock_time_t;
 #else /* WITH_CONTIKI || RIOT_VERSION */
 
+#ifdef HAVE_TIME_H
 #include <time.h>
+#endif /* HAVE_TIME_H */
 
 #ifndef CLOCK_SECOND
 # define CLOCK_SECOND 1000

--- a/sha2/sha2speed.c
+++ b/sha2/sha2speed.c
@@ -35,7 +35,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#ifdef HAVE_SYS_TIME_H
 #include <sys/time.h>
+#endif /* HAVE_SYS_TIME_H */
 
 #include "sha2.h"
 

--- a/tests/dsrv-test.c
+++ b/tests/dsrv-test.c
@@ -4,7 +4,9 @@
 #include <netinet/in.h>
 #include <sys/types.h>
 #include <sys/socket.h>
+#ifdef HAVE_SYS_TIME_H
 #include <sys/time.h>
+#endif /* HAVE_SYS_TIME_H */
 
 #include "dsrv.h" 
 

--- a/tests/dtls-client.c
+++ b/tests/dtls-client.c
@@ -11,7 +11,10 @@
 #include <netinet/in.h>
 #include <sys/types.h>
 #include <sys/socket.h>
+#ifdef HAVE_SYS_TIME_H
 #include <sys/time.h>
+#endif /* HAVE_SYS_TIME_H */
+
 #include <arpa/inet.h>
 #include <netdb.h>
 #include <signal.h>

--- a/tests/dtls-server.c
+++ b/tests/dtls-server.c
@@ -10,7 +10,9 @@
 #include <netinet/in.h>
 #include <sys/types.h>
 #include <sys/socket.h>
+#ifdef HAVE_SYS_TIME_H
 #include <sys/time.h>
+#endif /* HAVE_SYS_TIME_H */
 #include <netdb.h>
 #include <signal.h>
 


### PR DESCRIPTION
Include time.h and sys/time.h based on HAVE_TIME_H and HAVE_SYS_TIME_H.

A first port for zephyr shows, that accidentally included time headers cause some other headers (socket) to fail. Easiest work-around is to switch these includes using the available macros. 

Signed-off-by: Achim Kraus <achim.kraus@bosch.io>