### PR TITLE
dtls_time: migrate to ztimer_msec

### DIFF
--- a/dtls_time.c
+++ b/dtls_time.c
@@ -43,12 +43,12 @@ dtls_tick_t dtls_clock_offset;
 
 void
 dtls_clock_init(void) {
-  dtls_clock_offset = xtimer_now64().ticks64;
+  dtls_clock_offset = ztimer_now(ZTIMER_MSEC);
 }
 
 void
 dtls_ticks(dtls_tick_t *t) {
-  *t = xtimer_now64().ticks64 -dtls_clock_offset;
+  *t = ztimer_now(ZTIMER_MSEC) - dtls_clock_offset;
 }
 
 #endif /* RIOT_VERSION */

--- a/dtls_time.h
+++ b/dtls_time.h
@@ -42,15 +42,16 @@
 
 #elif defined(RIOT_VERSION)
 
-#include <xtimer.h>
+#include "ztimer.h"
+#include "timex.h"
 
 /* this macro is already present on FreeBSD
    which causes a redefine error otherwise */
 #ifndef CLOCK_SECOND
-#define CLOCK_SECOND (xtimer_ticks_from_usec64(1000000UL).ticks64)
+#define CLOCK_SECOND (MS_PER_SEC)
 #endif
 
-typedef uint64_t clock_time_t;
+typedef uint32_t clock_time_t;
 
 #else /* WITH_CONTIKI || RIOT_VERSION */
 


### PR DESCRIPTION
RIOT is currently migrating from its [xtimer](https://doc.riot-os.org/group__sys__xtimer.html) to [ztimer](https://doc.riot-os.org/group__sys__ztimer.html) high level timer abstraction.

The new API allows better sleep management. `xtimer` was based in microseconds and in this library-port, it was using 64bits. This PR is changing it to use `ztimer_msec`, so milliseconds based. It's also using 32bits timestamps instead of 64bits used by `xtimer`.

Since `contiki` also uses 32bits my assumption is that a 32bit millisecond timer should be enough as a backend for the `dtls_time` api, is there any reason why this assumption would be wrong?

I have provided test results for this in the PR making this change in RIOT-OS/RIOT, (see https://github.com/RIOT-OS/RIOT/pull/17564). In that PR this change is provided as a patch, but if this PR is accepted I can simply change the commit hash.