### PR TITLE
session.h: Modify session_t for RIOT

### DIFF
--- a/session.c
+++ b/session.c
@@ -34,8 +34,8 @@
 #elif defined(WITH_RIOT_GNRC)
 #define _dtls_address_equals_impl(A,B)                          \
   ((A)->size == (B)->size                                       \
-   && (A)->port == (B)->port                                    \
-   && ipv6_addr_equal(&((A)->addr),&((B)->addr))                \
+   && (A)->addr.port == (B)->addr.port                                    \
+   && ipv6_addr_equal(&((A)->addr.addr6),&((B)->addr.addr6))                \
    && (A)->ifindex == (B)->ifindex)
 #else /* WITH_CONTIKI */
 

--- a/session.h
+++ b/session.h
@@ -25,10 +25,10 @@
 #ifdef WITH_CONTIKI
 #include "ip/uip.h"
 typedef struct {
-  unsigned char size;
-  uip_ipaddr_t addr;
-  unsigned short port;
-  int ifindex;
+  unsigned char size;     /**< size of session_t::addr */
+  uip_ipaddr_t addr;      /**< session IP address */
+  unsigned short port;    /**< transport layer port */
+  int ifindex;            /**< network interface index */
 } session_t;
  /* TODO: Add support for RIOT over sockets  */
 #elif defined(WITH_RIOT_GNRC)

--- a/session.h
+++ b/session.h
@@ -34,10 +34,12 @@ typedef struct {
 #elif defined(WITH_RIOT_GNRC)
 #include "net/ipv6/addr.h"
 typedef struct {
-  unsigned char size;
-  ipv6_addr_t addr;
-  unsigned short port;
-  int ifindex;
+  unsigned char size;     /**< size of session_t::addr */
+  struct {
+    unsigned short port;  /**< transport layer port */
+    ipv6_addr_t addr6;    /**< IPv6 address */
+  } addr;                 /**< session IP address and port */
+  int ifindex;            /**< network interface index */
 } session_t;
 #else /* ! WITH_CONTIKI && ! WITH_RIOT_GNRC */
 


### PR DESCRIPTION
As described in https://github.com/RIOT-OS/RIOT/pull/17849, having `port` and `addr` as separate fields in the `session_t` was causing in certain scenarios to include random bytes (possible due to padding) to the hash calculation for the cookie. This would in turn cause the server to generate inconsistent cookies, thus failing to perform the handshake.

This PR joins the port and the IPv6 address into a single member, which is used to calculate the size.
