### PR TITLE
Rename condition WITH_RIOT_GNRC to WITH_RIOT_SOCK

### DIFF
--- a/session.c
+++ b/session.c
@@ -31,7 +31,7 @@
    && (A)->port == (B)->port					\
    && uip_ipaddr_cmp(&((A)->addr),&((B)->addr))			\
    && (A)->ifindex == (B)->ifindex)
-#elif defined(WITH_RIOT_GNRC)
+#elif defined(WITH_RIOT_SOCK)
 #define _dtls_address_equals_impl(A,B)                          \
   ((A)->size == (B)->size                                       \
    && (A)->port == (B)->port                                    \

--- a/session.h
+++ b/session.h
@@ -31,7 +31,7 @@ typedef struct {
   int ifindex;
 } session_t;
  /* TODO: Add support for RIOT over sockets  */
-#elif defined(WITH_RIOT_GNRC)
+#elif defined(WITH_RIOT_SOCK)
 #include "net/ipv6/addr.h"
 typedef struct {
   unsigned char size;
@@ -39,7 +39,7 @@ typedef struct {
   unsigned short port;
   int ifindex;
 } session_t;
-#else /* ! WITH_CONTIKI && ! WITH_RIOT_GNRC */
+#else /* ! WITH_CONTIKI && ! WITH_RIOT_SOCK */
 
 #include <sys/socket.h>
 #include <netinet/in.h>
@@ -55,7 +55,7 @@ typedef struct {
   } addr;
   int ifindex;
 } session_t;
-#endif /* ! WITH_CONTIKI && ! WITH_RIOT_GNRC */
+#endif /* ! WITH_CONTIKI && ! WITH_RIOT_SOCK */
 
 /** 
  * Resets the given session_t object @p sess to its default


### PR DESCRIPTION
Using tinydtls on RIOT OS is not limited to GNRC as network stack. It is also working with e.g. lwIP, see: https://github.com/RIOT-OS/RIOT/pull/17552. Therefore the name WITH_RIOT_GNRC is misleading.

PR in RIOT OS has already been approved and was merged: 
- https://github.com/RIOT-OS/RIOT/pull/17765