### PR TITLE
Add IPv4 support for RIOT OS

### DIFF
--- a/session.c
+++ b/session.c
@@ -32,11 +32,23 @@
    && uip_ipaddr_cmp(&((A)->addr),&((B)->addr))			\
    && (A)->ifindex == (B)->ifindex)
 #elif defined(WITH_RIOT_SOCK)
-#define _dtls_address_equals_impl(A,B)                          \
-  ((A)->size == (B)->size                                       \
-   && (A)->addr.port == (B)->addr.port                                    \
-   && ipv6_addr_equal(&((A)->addr.addr6),&((B)->addr.addr6))                \
-   && (A)->ifindex == (B)->ifindex)
+#include "net/af.h"
+#ifdef SOCK_HAS_IPV4
+#define _dtls_ipv4_address_equals_impl(A,B)                   \
+    ((A)->size == (B)->size                                   \
+     && (A)->addr.port == (B)->addr.port                      \
+     && (A)->ifindex == (B)->ifindex)                         \
+     && (A)->addr.family == (B)->addr.family                  \
+     && ipv4_addr_equal(&((A)->addr.ipv4),&((B)->addr.ipv4))
+#endif
+#ifdef SOCK_HAS_IPV6
+#define _dtls_ipv6_address_equals_impl(A,B)                   \
+    ((A)->size == (B)->size                                   \
+     && (A)->addr.port == (B)->addr.port                      \
+     && (A)->ifindex == (B)->ifindex)                         \
+     && (A)->addr.family == (B)->addr.family                  \
+     && ipv6_addr_equal(&((A)->addr.ipv6),&((B)->addr.ipv6))
+#endif
 #else /* WITH_CONTIKI */
 
 static inline int 
@@ -120,5 +132,21 @@ dtls_session_addr(session_t *sess, socklen_t *addrlen) {
 int
 dtls_session_equals(const session_t *a, const session_t *b) {
   assert(a); assert(b);
+#ifdef RIOT_VERSION
+  switch (a->addr.family) {
+#ifdef SOCK_HAS_IPV4
+  case AF_INET:
+    return _dtls_ipv4_address_equals_impl(a, b);
+#endif
+#ifdef SOCK_HAS_IPV6
+  case AF_INET6:
+    return _dtls_ipv6_address_equals_impl(a, b);
+#endif
+  default:
+    assert(0);
+    return false;
+  }
+#else
   return _dtls_address_equals_impl(a, b);
+#endif /* RIOT_VERSION */
 }

--- a/session.h
+++ b/session.h
@@ -32,14 +32,23 @@ typedef struct {
 } session_t;
  /* TODO: Add support for RIOT over sockets  */
 #elif defined(WITH_RIOT_SOCK)
+#include "net/ipv4/addr.h"
 #include "net/ipv6/addr.h"
 typedef struct {
-  unsigned char size;     /**< size of session_t::addr */
+  unsigned char size;       /**< size of session_t::addr */
   struct {
-    unsigned short port;  /**< transport layer port */
-    ipv6_addr_t addr6;    /**< IPv6 address */
-  } addr;                 /**< session IP address and port */
-  int ifindex;            /**< network interface index */
+    unsigned short family;  /**< IP address family */
+    unsigned short port;    /**< transport layer port */
+    union {
+#ifdef SOCK_HAS_IPV4
+      ipv4_addr_t ipv4;     /**< IPv4 address */
+#endif
+#ifdef SOCK_HAS_IPV6
+      ipv6_addr_t ipv6;     /**< IPv6 address */
+#endif
+    };
+  } addr;                   /**< session IP address and port */
+  int ifindex;              /**< network interface index */
 } session_t;
 #else /* ! WITH_CONTIKI && ! WITH_RIOT_SOCK */
 


### PR DESCRIPTION
Add the capability to communicate using IPv4.

PR in RIOT OS has already been approved and was merged: 
- https://github.com/RIOT-OS/RIOT/pull/17765

Dependencies:
- #127
- #128

I'll rebase once the dependencies are merged.

Off-topic:
At first glance the project seemed to be stale, but after looking into the develop branch it became clear it is not. I just wanted to point out that some first-time users (like me) might get the wrong impression when they see that the latest commit to master is from July 2020 ;)