### PR TITLE
configure.ac: Prevent overwriting CFLAGS in configure

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -34,7 +34,7 @@ m4_ifdef([AM_PROG_AR], [AM_PROG_AR], [AR=ar])
 
 AC_C_BIGENDIAN
 
-CFLAGS="-fPIC"
+CFLAGS="${CFLAGS} -fPIC"
 
 # Adding some default warning options for code QS
 # see https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html


### PR DESCRIPTION
By setting CFLAGS in configure, commit b9c58a1f [1]
accidentally prevents passing additional CFLAGS
parameters into make.

[1] https://github.com/eclipse/tinydtls/commit/b9c58a1f237599402b1b3ecc339ea49c98de387d

Change-Id: Ibfb0a805e690cf401f77e53c9a58f4e75a668aa8