### PR TITLE
dtls.c: fix off-by-one error in dtls_asn1_len()

### DIFF
--- a/dtls.c
+++ b/dtls.c
@@ -2005,11 +2005,9 @@ dtls_asn1_len(uint8 **data, size_t *data_len)
     (*data_len)--;
     if (octets && *data_len == 0)
       return (size_t)-1;
-    while (octets) {
+    while (octets > 0 && *data_len > 0) {
       len = (len << 8) + (**data);
       (*data)++;
-      if (*data_len == 0)
-        return (size_t)-1;
       (*data_len)--;
       octets--;
     }

--- a/dtls.c
+++ b/dtls.c
@@ -2003,9 +2003,9 @@ dtls_asn1_len(uint8 **data, size_t *data_len)
     size_t octets = (**data) & 0x7f;
     (*data)++;
     (*data_len)--;
-    if (octets && *data_len == 0)
+    if (octets > *data_len)
       return (size_t)-1;
-    while (octets > 0 && *data_len > 0) {
+    while (octets > 0) {
       len = (len << 8) + (**data);
       (*data)++;
       (*data_len)--;


### PR DESCRIPTION
For ASN.1 integers greater than 128 (i.e., with the most significant bit set) the encoded length might exceed *data_len. The length check in the while loop must be done after decrementing *data_len.

This PR addresses a bug reported by Shisong Qin, cf. #133

The function can be tested like this:

```c
int main() {
  uint8_t input[] = { 0x87, 0xab, 0xcd };
  uint8_t *data = input;
  size_t n = sizeof(input);
  dtls_asn1_len(&data, &n);
}
```

Compile with 

```
clang -O0 -fsanitize=address  check_asn1_len.c -o check_asn1_len
```

The erroneous function would cause the sanitizer to report a stack-buffer-overflow (see below) while staying silent for the fixed version.

```
=21072==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x7ffd6d54a863 at pc 0x0000004ce2d7 bp 0x7ffd6d54a740 sp 0x7ffd6d54a738
READ of size 1 at 0x7ffd6d54a863 thread T0
...
```