### PR TITLE
dtls.c: fix off-by-one error in dtls_asn1_len()

### DIFF
--- a/dtls.c
+++ b/dtls.c
@@ -1996,13 +1996,11 @@ dtls_asn1_len(uint8 **data, size_t *data_len)
     size_t octets = (**data) & 0x7f;
     (*data)++;
     (*data_len)--;
-    if (octets && *data_len == 0)
+    if (octets > *data_len)
       return (size_t)-1;
-    while (octets) {
+    while (octets > 0) {
       len = (len << 8) + (**data);
       (*data)++;
-      if (*data_len == 0)
-        return (size_t)-1;
       (*data_len)--;
       octets--;
     }


### PR DESCRIPTION
For ASN.1 integers greater than 128 (i.e., with the most significant bit set) the encoded length might exceed *data_len. The length check is done upfront to ensure that the specified number of octets does
not exceed the actual *data_len.

This bug was reported by Shisong Qin.

This PR supersedes PR #152.