### PR TITLE
dtls.c: Fix incomplete release of peer

### DIFF
--- a/dtls.c
+++ b/dtls.c
@@ -3884,9 +3884,7 @@ handle_0_verified_client_hello(dtls_context_t *ctx, dtls_ephemeral_peer_t *ephem
   dtls_peer_t *peer = dtls_get_peer(ctx, ephemeral_peer->session);
   if (peer) {
      dtls_debug("removing the peer, new handshake\n");
-     DEL_PEER(ctx->peers, peer);
-
-     dtls_free_peer(peer);
+     dtls_destroy_peer(ctx, peer, 0);
      peer = NULL;
   }
   dtls_debug("creating new peer\n");
@@ -3928,8 +3926,7 @@ handle_0_verified_client_hello(dtls_context_t *ctx, dtls_ephemeral_peer_t *ephem
 
   err = handle_verified_client_hello(ctx, peer, data, data_length);
   if (err < 0) {
-    DEL_PEER(ctx->peers, peer);
-    dtls_free_peer(peer);
+    dtls_destroy_peer(ctx, peer, DTLS_DESTROY_CLOSE);
     return err;
   }
 


### PR DESCRIPTION
In handle_0_verified_client_hello(), an existing peer is released and replaced by a new peer object. To ensure that references to this peer are cleared, dtls_destroy_peer() must be called with the unlink flag set.

Moreover, when handle_verified_client_hello() fails for the new peer structure, dtls_destroy_peer() must be called for that peer as well to ensure removal from the sendqueue.

This issue has been reported by Shisong Qin, cf. #133