### PR TITLE
dtls.c: introduce dtls_writev()

### DIFF
--- a/dtls.c
+++ b/dtls.c
@@ -304,8 +304,9 @@ dtls_add_peer(dtls_context_t *ctx, dtls_peer_t *peer) {
 }
 
 int
-dtls_write(struct dtls_context_t *ctx,
-	   session_t *dst, uint8 *buf, size_t len) {
+dtls_writev(struct dtls_context_t *ctx,
+	    session_t *dst, uint8 *buf_array[],
+	    size_t buf_len_array[], size_t buf_array_len) {
 
   dtls_peer_t *peer = dtls_get_peer(ctx, dst);
 
@@ -323,7 +324,9 @@ dtls_write(struct dtls_context_t *ctx,
     if (peer->state != DTLS_STATE_CONNECTED) {
       return 0;
     } else {
-      return dtls_send(ctx, peer, DTLS_CT_APPLICATION_DATA, buf, len);
+      return dtls_send_multi(ctx, peer, dtls_security_params(peer),
+                             &peer->session, DTLS_CT_APPLICATION_DATA,
+                             buf_array, buf_len_array, buf_array_len);
     }
   }
 }

--- a/dtls.h
+++ b/dtls.h
@@ -291,6 +291,23 @@ int dtls_close(dtls_context_t *ctx, const session_t *remote);
  */
 int dtls_renegotiate(dtls_context_t *ctx, const session_t *dst);
 
+/**
+ * Writes the application data given in multiple buffers to the peer
+ * specified by @p session.
+ *
+ * @param ctx      The DTLS context to use.
+ * @param session  The remote transport address and local interface.
+ * @param buf_array     Array of buffers with the data to write.
+ * @param buf_len_array The length of the arrays in @p buf_array.
+ * @param buf_array_len The number of data arrays.
+ *
+ * @return The number of bytes written, @c -1 on error or @c 0
+ *         if the peer already exists but is not connected yet.
+ */
+int dtls_writev(struct dtls_context_t *ctx,
+		session_t *session, uint8 *buf_array[],
+		size_t buf_len_array[], size_t buf_array_len);
+
 /** 
  * Writes the application data given in @p buf to the peer specified
  * by @p session. 
@@ -303,8 +320,11 @@ int dtls_renegotiate(dtls_context_t *ctx, const session_t *dst);
  * @return The number of bytes written, @c -1 on error or @c 0
  *         if the peer already exists but is not connected yet.
  */
-int dtls_write(struct dtls_context_t *ctx, session_t *session, 
-	       uint8 *buf, size_t len);
+static inline
+int dtls_write(struct dtls_context_t *ctx, session_t *session,
+	       uint8 *buf, size_t len) {
+  return dtls_writev(ctx, session, &buf, &len, 1);
+}
 
 /**
  * Checks sendqueue of given DTLS context object for any outstanding


### PR DESCRIPTION
`dtls.c` already provides a `dtls_send_multi()` function to send data from discontinuous buffers.

Also provide this functionality to the user, so e.g. protocol header and payload data can be supplied in separate buffers, removing the requirement for an additional work buffer on the application side.