### PR TITLE
dtls: redefine `dtls_write` without `static inline`

### DIFF
--- a/dtls.c
+++ b/dtls.c
@@ -331,6 +331,12 @@ dtls_writev(struct dtls_context_t *ctx,
   }
 }
 
+int
+dtls_write(struct dtls_context_t *ctx, session_t *session,
+	       uint8 *buf, size_t len) {
+  return dtls_writev(ctx, session, &buf, &len, 1);
+}
+
 static int
 dtls_get_cookie(uint8 *msg, size_t msglen, uint8 **cookie) {
   /* To access the cookie, we have to determine the session id's

--- a/dtls.h
+++ b/dtls.h
@@ -310,7 +310,7 @@ int dtls_writev(struct dtls_context_t *ctx,
 
 /** 
  * Writes the application data given in @p buf to the peer specified
- * by @p session. 
+ * by @p session.
  * 
  * @param ctx      The DTLS context to use.
  * @param session  The remote transport address and local interface.
@@ -320,11 +320,8 @@ int dtls_writev(struct dtls_context_t *ctx,
  * @return The number of bytes written, @c -1 on error or @c 0
  *         if the peer already exists but is not connected yet.
  */
-static inline
 int dtls_write(struct dtls_context_t *ctx, session_t *session,
-	       uint8 *buf, size_t len) {
-  return dtls_writev(ctx, session, &buf, &len, 1);
-}
+	       uint8 *buf, size_t len);
 
 /**
  * Checks sendqueue of given DTLS context object for any outstanding


### PR DESCRIPTION
While https://github.com/eclipse/tinydtls/pull/159 made a very useful addition by introducing `dtls_writev`, it made `dtls_write` unusable in shared libraries by turning it into a `static inline` function. This PR proposes reintroducing `dtls_write` as a "regular" function when not building for an RTOS (Contiki, RIOT, or Zephyr), making it available in shared libraries again.

Using a doxygen member group, it should be possible to reuse the documentation for both function variants, reducing redundancy.