### PR TITLE
LwIP: Support LwIP builds when NO_SYS = 1

### DIFF
--- a/dtls.c
+++ b/dtls.c
@@ -189,6 +189,9 @@ static const unsigned char cert_asn1_header[] = {
 
 PROCESS(dtls_retransmit_process, "DTLS retransmit process");
 
+#endif /* WITH_CONTIKI */
+
+#if defined(WITH_CONTIKI) ||  defined(WITH_LWIP)
 static dtls_context_t the_dtls_context;
 
 static inline dtls_context_t *
@@ -200,7 +203,7 @@ static inline void
 free_context(dtls_context_t *context) {
 }
 
-#endif /* WITH_CONTIKI */
+#endif /* WITH_CONTIKI || WITH_LWIP */
 
 #ifdef RIOT_VERSION
 static inline dtls_context_t *

--- a/dtls_debug.c
+++ b/dtls_debug.c
@@ -182,7 +182,7 @@ dsrv_print_addr(const session_t *addr, char *buf, size_t len) {
   len -= err;
 
   return p - buf;
-#else /* HAVE_INET_NTOP */
+#else /* ! HAVE_INET_NTOP */
 
 #ifdef WITH_CONTIKI
   char *p = buf;
@@ -236,7 +236,7 @@ dsrv_print_addr(const session_t *addr, char *buf, size_t len) {
 #endif /* WITH_POSIX */
 
   return 0;
-#endif /* HAVE_ARPA_INET_H */
+#endif /* ! HAVE_INET_NTOP */
 }
 
 #endif /* NDEBUG */

--- a/dtls_prng.c
+++ b/dtls_prng.c
@@ -33,6 +33,9 @@
 #elif defined (IS_WINDOWS)
 #include "platform-specific/dtls_prng_win.c"
 
+#elif defined (WITH_LWIP)
+#include "platform-specific/dtls_prng_lwip.c"
+
 #elif defined (WITH_POSIX)
 #include "platform-specific/dtls_prng_posix.c"
 

--- a/dtls_time.c
+++ b/dtls_time.c
@@ -41,9 +41,8 @@ dtls_ticks(dtls_tick_t *t) {
   *t = clock_time();
 }
 
-#endif /* WITH_CONTIKI */
+#elif defined(RIOT_VERSION)
 
-#ifdef RIOT_VERSION
 dtls_tick_t dtls_clock_offset;
 
 void
@@ -56,9 +55,7 @@ dtls_ticks(dtls_tick_t *t) {
   *t = ztimer_now(ZTIMER_MSEC) - dtls_clock_offset;
 }
 
-#endif /* RIOT_VERSION */
-
-#ifdef WITH_ZEPHYR
+#elif defined(WITH_ZEPHYR)
 
 void
 dtls_clock_init(void) {
@@ -67,6 +64,17 @@ dtls_clock_init(void) {
 void
 dtls_ticks(dtls_tick_t *t) {
   *t = k_uptime_get();
+}
+
+#elif defined(WITH_LWIP)
+
+void
+dtls_clock_init(void) {
+}
+
+void
+dtls_ticks(dtls_tick_t *t) {
+  *t = sys_now();
 }
 
 #elif defined(WITH_POSIX) || defined(IS_WINDOWS)
@@ -93,16 +101,17 @@ void dtls_ticks(dtls_tick_t *t) {
   gettimeofday(&tv, NULL);
   *t = (tv.tv_sec - dtls_clock_offset) * DTLS_TICKS_PER_SECOND 
     + (tv.tv_usec * DTLS_TICKS_PER_SECOND / 1000000);
+
 #elif defined(_MSC_VER)
+
   SYSTEMTIME current_time;
   GetSystemTime(&current_time);
   *t = (current_time.wSecond - dtls_clock_offset) * DTLS_TICKS_PER_SECOND 
     + (current_time.wMilliseconds * DTLS_TICKS_PER_SECOND / 1000);
+
 #else
 #error "clock not implemented"
 #endif
 }
 
-#endif /* WITH_POSIX */
-
-
+#endif /* ! CONTIKI && ! RIOT_VERSION && ! WITH_ZEPHYR && ! WITH_LWIP && ! WITH_POSIX */

--- a/dtls_time.h
+++ b/dtls_time.h
@@ -63,7 +63,16 @@ typedef uint32_t clock_time_t;
 
 typedef int64_t clock_time_t;
 
-#else /* WITH_CONTIKI || RIOT_VERSION */
+#elif defined(WITH_LWIP)
+#include "lwip/sys.h"
+
+#ifndef CLOCK_SECOND
+# define CLOCK_SECOND 1000
+#endif
+
+typedef uint32_t clock_time_t;
+
+#else /* ! WITH_CONTIKI && ! RIOT_VERSION && ! WITH_ZEPHYR && ! WITH_LWIP */
 
 #ifdef HAVE_TIME_H
 #include <time.h>
@@ -75,7 +84,7 @@ typedef int64_t clock_time_t;
 
 typedef uint32_t clock_time_t;
 
-#endif /* WITH_CONTIKI || RIOT_VERSION */
+#endif /* ! WITH_CONTIKI && ! RIOT_VERSION && ! WITH_ZEPHYR && ! WITH_LWIP */
 
 typedef clock_time_t dtls_tick_t;
 

--- a/platform-specific/dtls_prng_lwip.c
+++ b/platform-specific/dtls_prng_lwip.c
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ *
+ * Copyright (c) 2011-2022 Olaf Bergmann (TZI) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *    Olaf Bergmann  - initial API and implementation
+ *    Jon Shallow    - platform dependent prng support
+ *
+ *******************************************************************************/
+
+#include "tinydtls.h"
+#include "dtls_prng.h"
+#include <string.h>
+
+int
+dtls_prng(unsigned char *buf, size_t len) {
+  u32_t v = LWIP_RAND();
+  size_t k_len = len;
+
+  while (len > sizeof(v)) {
+    memcpy(buf, &v, sizeof(v));
+    len -= sizeof(v);
+    buf += sizeof(v);
+    v = LWIP_RAND();
+  }
+
+  memcpy(buf, &v, len);
+  return k_len;
+}
+
+void
+dtls_prng_init(unsigned seed) {
+  (void) seed;
+}
+

--- a/platform-specific/lwip_platform.h
+++ b/platform-specific/lwip_platform.h
@@ -1,0 +1,114 @@
+/************************************************************************/
+/* LwIP-specific parameters                                             */
+/************************************************************************/
+
+
+#ifndef _LWIP_PLATFORM_
+#define _LWIP_PLATFORM_
+
+/*
+ * SETTING FOR TINYDTLS OVER LWIP
+ * In standard installation of TinyDTLS they are at dtls_config.h
+ * Only those used by the main library (not test/ or test* files) are here.
+ */
+
+#include <lwip/opt.h>
+#if ! LWIP_SOCKET
+#define WITH_LWIP_NO_SOCKET
+#endif /* ! LWIP_SOCKET */
+
+#ifndef DTLS_ECC
+#define DTLS_ECC
+#endif /* DTLS_ECC */
+
+#ifndef DTLS_PSK
+#define DTLS_PSK
+#endif /* DTLS_PSK */
+
+/* LwIP supports  <assert.h> header file.  */
+#define HAVE_ASSERT_H 1
+
+/* LwIP supports  <inttypes.h> header file.  */
+#define HAVE_INTTYPES_H 1
+
+/* LwIP supports the member sin6_len */
+#define HAVE_SOCKADDR_IN6_SIN6_LEN 1
+
+/* LwIP supports the <sys/time.h> header file. */
+#define HAVE_SYS_TIME_H 1
+
+/* LwIP supports the <time.h> header file. */
+#define HAVE_TIME_H 1
+
+/* LwIP has partial support for the `vprintf' function. */
+/* DANGER Removing bring issues with dtls_debug.h and dtls_debug.c */
+#define HAVE_VPRINTF 1
+
+
+/*
+ * INFORMATION ABOUT TINYDTLS
+ * NOTE: This is used mostly by dtls_debug
+ */
+
+/* Define to the address where bug reports for this package should be sent. */
+#define PACKAGE_BUGREPORT ""
+
+/* Define to the full name of this package. */
+#define PACKAGE_NAME "tinydtls"
+
+/* Define to the full name and version of this package. */
+#define PACKAGE_STRING "tinydtls 0.8.6"
+
+/* Define to the one symbol short name of this package. */
+#define PACKAGE_TARNAME "tinydtls"
+
+/* Define to the home page for this package. */
+#define PACKAGE_URL ""
+
+/* Define to the version of this package. */
+#define PACKAGE_VERSION "0.8.6"
+
+
+
+/** do not use uthash's hash tables (the tables uses malloc/free) */
+#define DTLS_PEERS_NOHASH 1
+
+/*
+ * INFORMATION SHA2/ LIBRARY VARIABLES
+ *
+ * TODO: Clarify the way LwIP identifies BYTE_ORDER
+ */
+
+/*
+ * LwIP supports the  <inttypes.h> header file.
+ * NOTE: uintXX_t definitions with the ANSI C headers instead of custom typedef
+ */
+#define SHA2_USE_INTTYPES_H 1
+
+/* LwIP "supports" memset()/memcpy() BUT not bzero()/mcopy(). */
+#define SHA2_USE_MEMSET_MEMCPY 1
+
+
+/*
+ * NOTE Gcc is who define if we are big endian or little endian.
+ * Because LwIP has __BYTE_ORDER__ and BYTE_ORDER it is not clear which one
+ * should take preference here. Or, if the #define inside of sha2/sha2.h
+ * should be removed at all.
+ */
+#ifndef BIG_ENDIAN
+#if !defined(__BIG_ENDIAN__)
+#    define BIG_ENDIAN    4321
+#  else
+#    define BIG_ENDIAN    __BIG_ENDIAN__
+#  endif
+#endif
+
+#ifndef LITTLE_ENDIAN
+#if !defined(__LITTLE_ENDIAN__)
+#    define LITTLE_ENDIAN    1234
+#  else
+#    define LITTLE_ENDIAN    __LITTLE_ENDIAN__
+#  endif
+#endif
+
+#endif /* _LWIP_PLATFORM_ */

--- a/session.c
+++ b/session.c
@@ -31,7 +31,9 @@
    && (A)->port == (B)->port					\
    && uip_ipaddr_cmp(&((A)->addr),&((B)->addr))			\
    && (A)->ifindex == (B)->ifindex)
+
 #elif defined(WITH_RIOT_SOCK)
+
 #include "net/af.h"
 #ifdef SOCK_HAS_IPV4
 #define _dtls_ipv4_address_equals_impl(A,B)                   \
@@ -49,7 +51,16 @@
      && (A)->addr.family == (B)->addr.family                  \
      && ipv6_addr_equal(&((A)->addr.ipv6),&((B)->addr.ipv6))
 #endif
-#else /* WITH_CONTIKI */
+
+#elif defined(WITH_LWIP_NO_SOCKET)
+
+#define _dtls_address_equals_impl(A,B)				\
+  ((A)->size == (B)->size					\
+   && (A)->port == (B)->port					\
+   && ip_addr_cmp(&((A)->addr),&((B)->addr))			\
+   && (A)->ifindex == (B)->ifindex)
+
+#else /* ! WITH_CONTIKI && !WITH_RIOT_SOCK && ! WITH_LWIP_NO_SOCKET */
 
 static inline int 
 _dtls_address_equals_impl(const session_t *a,
@@ -74,7 +85,7 @@ _dtls_address_equals_impl(const session_t *a,
  }
  return 0;
 }
-#endif /* WITH_CONTIKI */
+#endif /* ! WITH_CONTIKI && !WITH_RIOT_SOCK && ! WITH_LWIP_NO_SOCKET */
 
 void
 dtls_session_init(session_t *sess) {
@@ -98,7 +109,7 @@ dtls_session_init(session_t *sess) {
  * for sessions and peers and store a pointer to a session in the peer
  * struct.
  */
-#if !(defined (WITH_CONTIKI)) && !(defined (RIOT_VERSION))
+#if !(defined (WITH_CONTIKI)) && !(defined (RIOT_VERSION)) && !(defined (WITH_LWIP_NO_SOCKET))
 session_t*
 dtls_new_session(struct sockaddr *addr, socklen_t addrlen) {
   session_t *sess;
@@ -127,7 +138,7 @@ dtls_session_addr(session_t *sess, socklen_t *addrlen) {
   *addrlen = sess->size;
   return &sess->addr.sa;
 }
-#endif /* !(defined (WITH_CONTIKI)) && !(defined (RIOT_VERSION)) */
+#endif /* ! WITH_CONTIKI && ! RIOT_VERSION && ! WITH_LWIP_NO_SOCKET */
 
 int
 dtls_session_equals(const session_t *a, const session_t *b) {

--- a/tinydtls.h
+++ b/tinydtls.h
@@ -36,6 +36,11 @@
 #define IS_WINDOWS 1
 #endif
 
+#ifdef WITH_LWIP
+#include "platform-specific/lwip_platform.h"
+#endif /* WITH_LWIP */
+
+#ifndef WITH_LWIP
 #ifndef CONTIKI
 #ifndef RIOT_VERSION
 #ifndef IS_WINDOWS
@@ -47,6 +52,7 @@
 #include "dtls_config.h"
 #endif /* RIOT_VERSION */
 #endif /* CONTIKI */
+#endif /* WITH_LWIP */
 
 #ifndef DTLS_ECC
 #ifndef DTLS_PSK


### PR DESCRIPTION
Follow the model of how things are done for Contiki.

Set up a new WITH_LWIP_NO_SOCKET (which happens with NO_SYS = 1)
and use this when setting up addresses.

Add in platform specific for dtls_prng_lwip.c and lwip_platform.h

Update dtls_time.[ch] to handle LWIP version of time.

Code works for NO_SYS = 1 or NO_SYS = 0.

Signed-off-by: Jon Shallow <supjps-libcoap@jpshallow.com>