### PR TITLE
LwIP: Fix unused parameter compiler warnings

### DIFF
--- a/dtls.c
+++ b/dtls.c
@@ -201,6 +201,7 @@ malloc_context(void) {
 
 static inline void
 free_context(dtls_context_t *context) {
+  (void)context;
 }
 
 #endif /* WITH_CONTIKI || WITH_LWIP */

--- a/dtls_debug.c
+++ b/dtls_debug.c
@@ -222,7 +222,7 @@ dsrv_print_addr(const session_t *addr, char *buf, size_t len) {
 
 #endif /* WITH_CONTIKI */
 
-#if defined(RIOT_VERSION) || defined(IS_WINDOWS)
+#if defined(RIOT_VERSION) || defined(IS_WINDOWS) || defined(WITH_LWIP)
   /* FIXME: Switch to RIOT own DEBUG lines */
   /* TODO: Check if inet_ntop can be used on Windows */
   (void) addr;


### PR DESCRIPTION
Found when libcoap LwIP builds removed the -Wno-unused-parameter option.

Signed-off-by: Jon Shallow <supjps-libcoap@jpshallow.com>