### PR TITLE
global.h: enable constrained stack if DTLS_MAX_BUF is too large

### DIFF
--- a/global.h
+++ b/global.h
@@ -57,6 +57,15 @@ typedef unsigned char uint48[6];
 #endif /* WITH_CONTIKI || RIOT_VERSION */
 #endif
 
+/*
+ * DTLS send buf is alloctaed on the stack by default
+ */
+#if !defined(DTLS_CONSTRAINED_STACK) && \
+    (defined(WITH_CONTIKI) || defined(RIOT_VERSION)) && \
+    (DTLS_MAX_BUF > 200)
+#define DTLS_CONSTRAINED_STACK 1
+#endif
+
 #ifndef DTLS_DEFAULT_MAX_RETRANSMIT
 /** Number of message retransmissions. */
 #define DTLS_DEFAULT_MAX_RETRANSMIT 7


### PR DESCRIPTION
When bumping `DTLS_MAX_BUF` to encrypt larger messages (e.g. to be sent over Ethernet) the size of the stack-allocated `sendbuf` will also grow.

This can lead to surprising crashes / stack corruption as thread stacks are usually not that large.

To prevent this, automatically enable `DTLS_CONSTRAINED_STACK` if `DTLS_MAX_BUF` is beyond a given threshold (default size with `DTLS_ECC`).