### PR TITLE
RIOT: make use od module for hexdump

### DIFF
--- a/dtls_debug.h
+++ b/dtls_debug.h
@@ -30,6 +30,7 @@
 
 #ifdef RIOT_VERSION
 #include "log.h"
+#include "od.h"
 #endif
 
 #ifdef WITH_CONTIKI
@@ -138,8 +139,8 @@ void dtls_dsrv_log_addr(log_t level, const char *name, const session_t *addr);
 #define dtls_notice(...) LOG_INFO(__VA_ARGS__)
 #define dtls_info(...) LOG_INFO(__VA_ARGS__)
 #define dtls_debug(...) LOG_DEBUG(__VA_ARGS__)
-#define dtls_debug_hexdump(name, buf, length) dtls_dsrv_hexdump_log(DTLS_LOG_DEBUG, name, buf, length, 1)
-#define dtls_debug_dump(name, buf, length) dtls_dsrv_hexdump_log(DTLS_LOG_DEBUG, name, buf, length, 0)
+#define dtls_debug_hexdump(name, buf, length) { if (LOG_DEBUG <= LOG_LEVEL) { LOG_DEBUG("-= %s (%zu bytes) =-\n", name, length); od_hex_dump(buf, length, 0); }}
+#define dtls_debug_dump(name, buf, length) { if (LOG_DEBUG <= LOG_LEVEL) { LOG_DEBUG("%s (%zu bytes):", name, length); od_hex_dump(buf, length, 0); }}
 #else /* neither RIOT nor Zephyr */
 #define dtls_emerg(...) dsrv_log(DTLS_LOG_EMERG, __VA_ARGS__)
 #define dtls_alert(...) dsrv_log(DTLS_LOG_ALERT, __VA_ARGS__)


### PR DESCRIPTION
While trying to figure out why tinydtls still requires `gettimeofday()` even though `dtls_ticks()` uses ZTimer now, I found that it's still used via `time()` in `dtls_dsrv_hexdump_log()`.

Replace it with a native hexdump function as it was done for Zephyr.

This allows us to drop the `gettimeofday` compat modules that was so far needed to build tinydtls with RIOT.

#### before

``` 
   text	   data	    bss	    dec	    hex	filename
 123068	    384	  24920	 148372	  24394	/home/benpicco/dev/RIOT/examples/dtls-sock/bin/openmote-b/dtls_sock.elf
```

#### with this patch

```
   text	   data	    bss	    dec	    hex	filename
 107756	    272	  24776	 132804	  206c4	/home/benpicco/dev/RIOT/examples/dtls-sock/bin/openmote-b/dtls_sock.elf
```