### PR TITLE
dtls.c: Reduce logging for unsupported tls extensions

### DIFF
--- a/dtls.c
+++ b/dtls.c
@@ -1204,7 +1204,7 @@ dtls_check_tls_extension(dtls_peer_t *peer,
           goto error;
         break;
       default:
-        dtls_warn("unsupported tls extension: %i\n", i);
+        dtls_notice("unsupported tls extension: %i\n", i);
         break;
     }
     data += j;


### PR DESCRIPTION
Every unsupported tls extension is logged using dtls_warn(), and the default logging level is set to DTLS_LOG_WARN.

Update logging call to dtls_notice(), to reduce logging output noise.