### PR TITLE
Replace pre-processor symbols for gnu source with posix in examples

### DIFF
--- a/tests/Makefile.in
+++ b/tests/Makefile.in
@@ -33,7 +33,7 @@ SOURCES:= dtls-server.c ccm-test.c \
 OBJECTS:= $(patsubst %.c, %.o, $(SOURCES))
 PROGRAMS:= dtls-server dtls-client ccm-test
 HEADERS:=
-CFLAGS:=-Wall -std=c99 @CFLAGS@ @WARNING_CFLAGS@ $(EXTRA_CFLAGS) -D_GNU_SOURCE
+CFLAGS:=-Wall -std=c99 @CFLAGS@ @WARNING_CFLAGS@ $(EXTRA_CFLAGS) -D_POSIX_C_SOURCE=200112L
 CPPFLAGS:=-I$(top_srcdir) @CPPFLAGS@
 LDFLAGS:=-L$(top_builddir) @LDFLAGS@
 LDLIBS:=$(top_srcdir)/libtinydtls.a @LIBS@

--- a/tests/dtls-client.c
+++ b/tests/dtls-client.c
@@ -50,6 +50,12 @@
 #define UNUSED_PARAM
 #endif /* __GNUC__ */
 
+#ifndef NI_MAXSERV
+/* Set a default value for NI_MAXSERV in case it does not get defined
+ * by netdb.h */
+#define NI_MAXSERV 32
+#endif
+
 typedef struct {
   size_t length;               /* length of string */
   unsigned char *s;            /* string data */


### PR DESCRIPTION
As discussed in PR #194 the pre-processor symbol `_GNU_SOURCE` used in the examples` Makefile could be replaced by `_POSIX_C_SOURCE=200112L` to provide the functions `kill()` and `getaddrinfo()`.
The drawback is that `NI_MAXSERV` then needs to be defined manually.