### PR TITLE
WIP: Update crypto API to use a Microship secure element such as ATECC608A

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,9 @@ CMakeFiles
 tinydtls.dir
 Debug
 Release
+
+compile_commands.json
+
+.cache/
+
+libtinydtls.so*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,7 @@ option(make_tests "Make test programs and examples" OFF)
 if(NOT PLATFORM)
    # PLATFORM seems to be not used
    set(PLATFORM "posix" CACHE STRING "Choose platform." FORCE)
-   set_property(CACHE PLATFORM PROPERTY STRINGS "posix" "riot")
+   set_property(CACHE PLATFORM PROPERTY STRINGS "contiki" "espidf" "posix" "riot" "zephyr" "windows")
 endif()
 
 set(PACKAGE_NAME "tinydtls")
@@ -62,7 +62,7 @@ set(SOVERSION "0" )
 
 if(NOT ZEPHYR_BASE)
    option(DTLS_ECC "disable/enable support for TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8" ON )
-   option(DTLS_PSK "disable/enable support for TLS_PSK_WITH_AES_128_CCM_8" OFF)
+   option(DTLS_PSK "disable/enable support for TLS_PSK_WITH_AES_128_CCM_8" ON)
 else()
    # provided by zephyr/CMakeLists.txt and zephyr/Kconfig
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,8 +25,23 @@ project(tinydtls)
 
 include (AutoConf.cmake)
 
+# Include the toolchain file
+if (CMAKE_SYSTEM_NAME STREQUAL "Generic" AND CMAKE_SYSTEM_PROCESSOR STREQUAL "arm")
+    set(CMAKE_SYSTEM_NAME Generic)
+    set(CMAKE_SYSTEM_PROCESSOR arm)
+
+    set(CMAKE_C_COMPILER arm-none-eabi-gcc)
+    set(CMAKE_CXX_COMPILER arm-none-eabi-g++)
+    set(CMAKE_ASM_COMPILER arm-none-eabi-gcc)
+    set(CMAKE_OBJCOPY arm-none-eabi-objcopy)
+
+    set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+    set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+    set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+endif()
+
 if(NOT ZEPHYR_BASE)
-   option(BUILD_SHARED_LIBS "Link using shared libs" OFF)
+   option(BUILD_SHARED_LIBS "Link using shared libs" ON)
 else()
     # provided by the zephyr build system
 endif()
@@ -36,7 +51,7 @@ option(make_tests "Make test programs and examples" OFF)
 if(NOT PLATFORM)
    # PLATFORM seems to be not used
    set(PLATFORM "posix" CACHE STRING "Choose platform." FORCE)
-   set_property(CACHE PLATFORM PROPERTY STRINGS "contiki" "espidf" "posix" "riot" "zephyr" "windows")
+   set_property(CACHE PLATFORM PROPERTY STRINGS "posix" "riot")
 endif()
 
 set(PACKAGE_NAME "tinydtls")
@@ -45,7 +60,7 @@ set(SOVERSION "0" )
 
 if(NOT ZEPHYR_BASE)
    option(DTLS_ECC "disable/enable support for TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8" ON )
-   option(DTLS_PSK "disable/enable support for TLS_PSK_WITH_AES_128_CCM_8" ON)
+   option(DTLS_PSK "disable/enable support for TLS_PSK_WITH_AES_128_CCM_8" OFF)
 else()
    # provided by zephyr/CMakeLists.txt and zephyr/Kconfig
 endif()
@@ -72,8 +87,15 @@ target_sources(tinydtls PRIVATE
    sha2/sha2.c
    ecc/ecc.c)
 
-target_include_directories(tinydtls PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR})
+set(CMAKE_CRYPTOAUTHLIB_PATH "/usr/include/cryptoauthlib")
+
+# Link cryptoauthlib to your project
+target_link_libraries(tinydtls cryptoauth)
+target_include_directories(tinydtls PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CRYPTOAUTHLIB_PATH} ${CMAKE_PLATFORM_SPE})
 target_compile_definitions(tinydtls PUBLIC DTLSv12 WITH_SHA256 SHA2_USE_INTTYPES_H DTLS_CHECK_CONTENTTYPE)
+# Add the preprocessor definition
+target_compile_definitions(tinydtls PRIVATE DTLS_ATECC608A)
+# target_compile_definitions(tinydtls PRIVATE DTLS_MICRO_ECC)
 
 if(CMAKE_GENERATOR MATCHES "Visual Studio")
     option(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS "Export all symbols when compiling to a .dll" ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,8 @@ project(tinydtls)
 
 include (AutoConf.cmake)
 
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 # Include the toolchain file
 if (CMAKE_SYSTEM_NAME STREQUAL "Generic" AND CMAKE_SYSTEM_PROCESSOR STREQUAL "arm")
     set(CMAKE_SYSTEM_NAME Generic)
@@ -95,7 +97,6 @@ target_include_directories(tinydtls PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_C
 target_compile_definitions(tinydtls PUBLIC DTLSv12 WITH_SHA256 SHA2_USE_INTTYPES_H DTLS_CHECK_CONTENTTYPE)
 # Add the preprocessor definition
 target_compile_definitions(tinydtls PRIVATE DTLS_ATECC608A)
-# target_compile_definitions(tinydtls PRIVATE DTLS_MICRO_ECC)
 
 if(CMAKE_GENERATOR MATCHES "Visual Studio")
     option(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS "Export all symbols when compiling to a .dll" ON)

--- a/crypto.c
+++ b/crypto.c
@@ -151,12 +151,6 @@ void crypto_init(ATCAIfaceCfg *config)
       dtls_alert("atcab_init success\n");
   }
 }
-
-void dtls_set_slot_id(uint8_t ecc_slot, uint8_t ecdhe_slot)
-{
-  ecdhe_slot_id = ecdhe_slot;
-  ecc_slot_id = ecc_slot;
-}
 #endif /* DTLS_ATECC608A */
 
 static dtls_handshake_parameters_t *dtls_handshake_malloc(void) {

--- a/crypto.h
+++ b/crypto.h
@@ -30,6 +30,10 @@
 #include "hmac.h"
 #include "ccm.h"
 
+#ifdef DTLS_ATECC608A
+#include "cryptoauthlib.h"
+#endif /* ATECC608A */
+
 /* TLS_PSK_WITH_AES_128_CCM_8 */
 #define DTLS_MAC_KEY_LENGTH    0
 #define DTLS_KEY_LENGTH        16 /* AES-128 */
@@ -219,6 +223,12 @@ typedef struct {
 
 /* just for consistency */
 #define dtls_kb_digest_size(Param, Role) DTLS_MAC_LENGTH
+
+#ifdef DTLS_ATECC608A
+uint8_t ecdhe_slot_id;
+
+uint8_t ecc_slot_id;
+#endif
 
 /** 
  * Expands the secret and key to a block of DTLS_HMAC_MAX 
@@ -467,7 +477,12 @@ void dtls_handshake_free(dtls_handshake_parameters_t *handshake);
 dtls_security_parameters_t *dtls_security_new(void);
 
 void dtls_security_free(dtls_security_parameters_t *security);
+
+#ifndef DTLS_ATECC608A  
 void crypto_init(void);
+#else
+void crypto_init(ATCAIfaceCfg *config);
+#endif /* ATECC608A */
 
 #endif /* _DTLS_CRYPTO_H_ */
 

--- a/crypto.h
+++ b/crypto.h
@@ -498,15 +498,6 @@ void dtls_security_free(dtls_security_parameters_t *security);
 void crypto_init(void);
 #else
 void crypto_init(ATCAIfaceCfg *config);
-
-/**
- * @brief Set the slot id used to perform ECDHE operation.
- * @warning Slot ID must be different.
- * 
- * @param ecc_slot Slot ID used to perform ECDSA operation.
- * @param ecdhe_slot Slot ID used to perform ECDHE operation.
- */
-void dtls_set_slot_id(uint8_t ecc_slot, uint8_t ecdhe_slot);
 #endif /* ATECC608A */
 
 #endif /* _DTLS_CRYPTO_H_ */

--- a/crypto.h
+++ b/crypto.h
@@ -225,9 +225,25 @@ typedef struct {
 #define dtls_kb_digest_size(Param, Role) DTLS_MAC_LENGTH
 
 #ifdef DTLS_ATECC608A
-uint8_t ecdhe_slot_id;
+/**
+ * @brief Slot id used to perform ECDHE operation. 
+ *        Due to the last 'E', the operation is performed with 
+ *        ephemeral keys that must be generated and stored in the
+ *        the current slot.
+ *        I advise to use slot configured as follows:
+ *          - SlotConfig[slot_id] = 0x2087
+ *          - KeyConfig[slot_id] = 0x0013
+ * @warning Slot ID must be different from ecc_slot_id.
+ */
+static uint8_t ecdhe_slot_id;
 
-uint8_t ecc_slot_id;
+/**
+ * @brief Slot id used to perform ECDSA operation.
+ *        This slot must contains the private key used to sign the
+ *        message. The associated public key is used to verify the signature.
+ * @warning Slot ID must be different from ecdhe_slot_id.
+ */
+static uint8_t ecc_slot_id;
 #endif
 
 /** 
@@ -482,6 +498,15 @@ void dtls_security_free(dtls_security_parameters_t *security);
 void crypto_init(void);
 #else
 void crypto_init(ATCAIfaceCfg *config);
+
+/**
+ * @brief Set the slot id used to perform ECDHE operation.
+ * @warning Slot ID must be different.
+ * 
+ * @param ecc_slot Slot ID used to perform ECDSA operation.
+ * @param ecdhe_slot Slot ID used to perform ECDHE operation.
+ */
+void dtls_set_slot_id(uint8_t ecc_slot, uint8_t ecdhe_slot);
 #endif /* ATECC608A */
 
 #endif /* _DTLS_CRYPTO_H_ */

--- a/dtls.c
+++ b/dtls.c
@@ -324,6 +324,7 @@ free_context(dtls_context_t *context) {
 
 #endif /* WITH_POSIX */
 
+#ifndef DTLS_ATECC608A
 void
 dtls_init(void) {
   dtls_clock_init();
@@ -336,6 +337,20 @@ memarray_init(&dtlscontext_storage, dtlscontext_storage_data,
               sizeof(dtls_context_t), DTLS_CONTEXT_MAX);
 #endif /* RIOT_VERSION */
 }
+#else 
+void dtls_init(ATCAIfaceCfg *cfg)
+{
+  dtls_clock_init();
+  crypto_init(cfg);
+  netq_init();
+  peer_init();
+
+#ifdef RIOT_VERSION
+memarray_init(&dtlscontext_storage, dtlscontext_storage_data,
+              sizeof(dtls_context_t), DTLS_CONTEXT_MAX);
+#endif /* RIOT_VERSION */
+}
+#endif /* DTLS_ATECC608A */
 
 /* Calls cb_alert() with given arguments if defined, otherwise an
  * error message is logged and the result is -1. This is just an
@@ -653,7 +668,6 @@ static const dtls_user_parameters_t default_user_parameters = {
     {
 #ifdef DTLS_ECC
       TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8,
-      TLS_ECDHE_ECDSA_WITH_AES_128_CCM,
 #endif /* DTLS_ECC */
 #ifdef DTLS_PSK
       TLS_PSK_WITH_AES_128_CCM_8,
@@ -695,7 +709,6 @@ static const struct cipher_suite_param_t cipher_suite_params[] = {
 #endif /* DTLS_PSK */
 #ifdef DTLS_ECC
   { TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8,  8, DTLS_KEY_EXCHANGE_ECDHE_ECDSA },
-  { TLS_ECDHE_ECDSA_WITH_AES_128_CCM,   16, DTLS_KEY_EXCHANGE_ECDHE_ECDSA },
 #endif /* DTLS_ECC */
  };
 
@@ -2432,15 +2445,15 @@ check_client_certificate_verify(dtls_context_t *ctx,
   copy_hs_hash(peer, &hs_hash);
 
   dtls_hash_finalize(sha256hash, &hs_hash);
-
+  
   ret = dtls_ecdsa_verify_sig_hash(config->keyx.ecdsa.other_pub_x,
                                    config->keyx.ecdsa.other_pub_y,
                                    sizeof(config->keyx.ecdsa.other_pub_x),
                                    sha256hash, sizeof(sha256hash),
                                    result_r, result_s);
-
+                                   
   if (ret < 0) {
-    dtls_alert("wrong signature err: %i\n", ret);
+    dtls_alert("check_client_certificate_verify : wrong signature err: %i\n", ret);
     return dtls_alert_fatal_create(DTLS_ALERT_HANDSHAKE_FAILURE);
   }
   return 0;
@@ -2962,7 +2975,7 @@ dtls_send_client_key_exchange(dtls_context_t *ctx, dtls_peer_t *peer)
       p += DTLS_EC_KEY_SIZE;
       ephemeral_pub_y = p;
       p += DTLS_EC_KEY_SIZE;
-
+      
     dtls_ecdsa_generate_key(peer->handshake_params->keyx.ecdsa.own_eph_priv,
     			    ephemeral_pub_x, ephemeral_pub_y,
     			    DTLS_EC_KEY_SIZE);
@@ -3419,9 +3432,13 @@ check_server_certificate(dtls_context_t *ctx,
 	     config->keyx.ecdsa.other_pub_x,
 	     config->keyx.ecdsa.other_pub_y,
 	     sizeof(config->keyx.ecdsa.other_pub_x));
+       
   if (err < 0) {
     dtls_warn("The certificate was not accepted\n");
     return err;
+  }
+  else {
+    dtls_debug("The certificate was accepted\n");
   }
 
   return 0;
@@ -3458,14 +3475,14 @@ check_server_key_exchange_ecdsa(dtls_context_t *ctx,
   key_params = data;
 
   if (dtls_uint8_to_int(data) != TLS_EC_CURVE_TYPE_NAMED_CURVE) {
-    dtls_alert("Only named curves supported\n");
+    dtls_alert("Only named curves supported : %d\n", dtls_uint8_to_int(data));
     return dtls_alert_fatal_create(DTLS_ALERT_HANDSHAKE_FAILURE);
   }
   data += sizeof(uint8);
   data_length -= sizeof(uint8);
 
   if (dtls_uint16_to_int(data) != TLS_EXT_ELLIPTIC_CURVES_SECP256R1) {
-    dtls_alert("secp256r1 supported\n");
+    dtls_alert("secp256r1 supported : %d\n", dtls_uint16_to_int(data));
     return dtls_alert_fatal_create(DTLS_ALERT_HANDSHAKE_FAILURE);
   }
   data += sizeof(uint16);
@@ -3509,7 +3526,7 @@ check_server_key_exchange_ecdsa(dtls_context_t *ctx,
 			    result_r, result_s);
 
   if (ret < 0) {
-    dtls_alert("wrong signature\n");
+    dtls_alert("check_server_key_exchange_ecdsa : wrong signature\n");
     return dtls_alert_fatal_create(DTLS_ALERT_HANDSHAKE_FAILURE);
   }
   return 0;

--- a/dtls.c
+++ b/dtls.c
@@ -350,6 +350,12 @@ memarray_init(&dtlscontext_storage, dtlscontext_storage_data,
               sizeof(dtls_context_t), DTLS_CONTEXT_MAX);
 #endif /* RIOT_VERSION */
 }
+
+void dtls_set_slot_id(uint8_t ecc_slot, uint8_t ecdhe_slot)
+{
+  ecdhe_slot_id = ecdhe_slot;
+  ecc_slot_id = ecc_slot;
+}
 #endif /* DTLS_ATECC608A */
 
 /* Calls cb_alert() with given arguments if defined, otherwise an

--- a/dtls.h
+++ b/dtls.h
@@ -251,6 +251,9 @@ typedef struct dtls_context_t {
 #ifndef DTLS_ATECC608A
 void dtls_init(void);
 
+#else
+void dtls_init(ATCAIfaceCfg *cfg);
+
 /**
  * @brief Set the slot id used to perform ECDHE operation.
  * @warning Slot ID must be different.
@@ -259,8 +262,6 @@ void dtls_init(void);
  * @param ecdhe_slot Slot ID used to perform ECDHE operation.
  */
 void dtls_set_slot_id(uint8_t ecc_slot, uint8_t ecdhe_slot);
-#else
-void dtls_init(ATCAIfaceCfg *cfg);
 
 void dtls_test_ATECC608A(void);
 #endif /* ATECC608A */

--- a/dtls.h
+++ b/dtls.h
@@ -40,6 +40,10 @@
 #include "global.h"
 #include "dtls_time.h"
 
+#ifdef DTLS_ATECC608A
+#include "cryptoauthlib.h"
+#endif /* ATECC608A */
+
 #ifndef DTLSv12
 #define DTLS_VERSION 0xfeff	/* DTLS v1.1 */
 #else
@@ -244,7 +248,13 @@ typedef struct dtls_context_t {
  * This function initializes the tinyDTLS memory management and must
  * be called first.
  */
+#ifndef DTLS_ATECC608A
 void dtls_init(void);
+#else
+void dtls_init(ATCAIfaceCfg *cfg);
+
+void dtls_test_ATECC608A(void);
+#endif /* ATECC608A */
 
 /** 
  * Creates a new context object. The storage allocated for the new

--- a/dtls.h
+++ b/dtls.h
@@ -257,7 +257,6 @@ void dtls_init(ATCAIfaceCfg *cfg);
 /**
  * @brief Set the slot id used to perform ECDHE operation.
  * @warning Slot ID must be different.
- * 
  * @param ecc_slot Slot ID used to perform ECDSA operation.
  * @param ecdhe_slot Slot ID used to perform ECDHE operation.
  */

--- a/dtls.h
+++ b/dtls.h
@@ -250,6 +250,15 @@ typedef struct dtls_context_t {
  */
 #ifndef DTLS_ATECC608A
 void dtls_init(void);
+
+/**
+ * @brief Set the slot id used to perform ECDHE operation.
+ * @warning Slot ID must be different.
+ * 
+ * @param ecc_slot Slot ID used to perform ECDSA operation.
+ * @param ecdhe_slot Slot ID used to perform ECDHE operation.
+ */
+void dtls_set_slot_id(uint8_t ecc_slot, uint8_t ecdhe_slot);
 #else
 void dtls_init(ATCAIfaceCfg *cfg);
 


### PR DESCRIPTION
I am working on boards that embed an ATECC608A (Microchip secure element), and I would like to perform all ECC/ECDH operations using it. This approach offers the benefit of enhanced security, as private keys are not directly manipulated.

Initially, I am working with RIOT. When I started looking for solutions to secure RF communication, I came across tinydtls and was convinced by its implementation of DTLS. I noticed some issues on my board (reported here [Issue 224](https://github.com/eclipse/tinydtls/issues/224)), and a PR to replace ecc with micro-ecc is now open ([PR 229](https://github.com/eclipse/tinydtls/pull/229)).

Micro-ecc works on my boards and significantly accelerates the handshake process. However, as mentioned earlier, I have an ATECC608A on my boards, so I would like to add a feature allowing users to choose whether to use it or not.

Since not all boards embed a secure element, I have added an environment variable (DTLS_ATECC608A) to give users the choice to use it or not. The CryptoAuth library is used to control the secure element ([CryptoAuthLib](https://github.com/MicrochipTech/cryptoauthlib)).

This PR is still a work in progress, but I have opened it so that we can discuss and improve my work.