### PR TITLE
WIP: Update crypto API to use a Microship secure element such as ATECC608A

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,9 @@ CMakeFiles
 tinydtls.dir
 Debug
 Release
+
+compile_commands.json
+
+.cache/
+
+libtinydtls.so*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,8 +25,25 @@ project(tinydtls)
 
 include (AutoConf.cmake)
 
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+# Include the toolchain file
+if (CMAKE_SYSTEM_NAME STREQUAL "Generic" AND CMAKE_SYSTEM_PROCESSOR STREQUAL "arm")
+    set(CMAKE_SYSTEM_NAME Generic)
+    set(CMAKE_SYSTEM_PROCESSOR arm)
+
+    set(CMAKE_C_COMPILER arm-none-eabi-gcc)
+    set(CMAKE_CXX_COMPILER arm-none-eabi-g++)
+    set(CMAKE_ASM_COMPILER arm-none-eabi-gcc)
+    set(CMAKE_OBJCOPY arm-none-eabi-objcopy)
+
+    set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+    set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+    set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+endif()
+
 if(NOT ZEPHYR_BASE)
-   option(BUILD_SHARED_LIBS "Link using shared libs" OFF)
+   option(BUILD_SHARED_LIBS "Link using shared libs" ON)
 else()
     # provided by the zephyr build system
 endif()
@@ -72,8 +89,14 @@ target_sources(tinydtls PRIVATE
    sha2/sha2.c
    ecc/ecc.c)
 
-target_include_directories(tinydtls PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR})
+set(CMAKE_CRYPTOAUTHLIB_PATH "/usr/include/cryptoauthlib")
+
+# Link cryptoauthlib to your project
+target_link_libraries(tinydtls cryptoauth)
+target_include_directories(tinydtls PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CRYPTOAUTHLIB_PATH} ${CMAKE_PLATFORM_SPE})
 target_compile_definitions(tinydtls PUBLIC DTLSv12 WITH_SHA256 SHA2_USE_INTTYPES_H DTLS_CHECK_CONTENTTYPE)
+# Add the preprocessor definition
+target_compile_definitions(tinydtls PRIVATE DTLS_ATECC608A)
 
 if(CMAKE_GENERATOR MATCHES "Visual Studio")
     option(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS "Export all symbols when compiling to a .dll" ON)

--- a/crypto.c
+++ b/crypto.c
@@ -15,10 +15,13 @@
  *
  *******************************************************************************/
 
+#include <stdbool.h>
 #include <stdio.h>
 
 #include "tinydtls.h"
-
+#ifdef DTLS_ATECC608A
+#include "cryptoauthlib.h"
+#endif
 #ifdef HAVE_ASSERT_H
 #include <assert.h>
 #else
@@ -74,9 +77,11 @@ static void dtls_cipher_context_release(void)
 }
 
 #if !(defined (WITH_CONTIKI)) && !(defined (RIOT_VERSION))
+#ifndef DTLS_ATECC608A
 void crypto_init(void)
 {
 }
+#endif
 
 static dtls_handshake_parameters_t *dtls_handshake_malloc(void) {
   return malloc(sizeof(dtls_handshake_parameters_t));
@@ -121,11 +126,32 @@ static void dtls_security_dealloc(dtls_security_parameters_t *security) {
 }
 
 #elif defined (RIOT_VERSION)
-
+#ifndef DTLS_ATECC608A
 void crypto_init(void) {
   memarray_init(&handshake_storage, handshake_storage_data, sizeof(dtls_handshake_parameters_t), DTLS_HANDSHAKE_MAX);
   memarray_init(&security_storage, security_storage_data, sizeof(dtls_security_parameters_t), DTLS_SECURITY_MAX);
 }
+#else
+static ATCAIfaceCfg atecc608a;
+
+void crypto_init(ATCAIfaceCfg *config)
+{
+  printf("Using ATECC608A\n");
+  memarray_init(&handshake_storage, handshake_storage_data, sizeof(dtls_handshake_parameters_t), DTLS_HANDSHAKE_MAX);
+  memarray_init(&security_storage, security_storage_data, sizeof(dtls_security_parameters_t), DTLS_SECURITY_MAX);
+  atecc608a = *config;
+  ATCA_STATUS status = atcab_init(config);
+  if (status != ATCA_SUCCESS)
+  {
+      dtls_alert("atcab_init failed with ret=0x%08x\n", status);
+      return;
+  }
+  else
+  {
+      dtls_alert("atcab_init success\n");
+  }
+}
+#endif /* DTLS_ATECC608A */
 
 static dtls_handshake_parameters_t *dtls_handshake_malloc(void) {
   return memarray_alloc(&handshake_storage);
@@ -438,6 +464,18 @@ int dtls_ecdh_pre_master_secret(unsigned char *priv_key,
                                    size_t key_size,
                                    unsigned char *result,
                                    size_t result_len) {
+#if defined (DTLS_ATECC608A)
+  (void)result_len;
+  (void)priv_key;
+  unsigned char pub_key[2 * ATCA_KEY_SIZE];
+  memcpy(pub_key, pub_key_x, ATCA_KEY_SIZE);
+  memcpy(pub_key + ATCA_KEY_SIZE, pub_key_y, ATCA_KEY_SIZE);
+  ATCA_STATUS status = atcab_ecdh(ecdhe_slot_id, pub_key, result);
+  if (status != ATCA_SUCCESS) {
+    dtls_alert("Failed to generate pre-master secret\n");
+    return -1;
+  }
+#else
   uint32_t priv[8];
   uint32_t pub_x[8];
   uint32_t pub_y[8];
@@ -456,6 +494,7 @@ int dtls_ecdh_pre_master_secret(unsigned char *priv_key,
   ecc_ecdh(pub_x, pub_y, priv, result_x, result_y);
 
   dtls_ec_key_from_uint32(result_x, key_size, result);
+#endif /* DTLS_ATECC608A */
   return key_size;
 }
 
@@ -464,6 +503,22 @@ dtls_ecdsa_generate_key(unsigned char *priv_key,
 			unsigned char *pub_key_x,
 			unsigned char *pub_key_y,
 			size_t key_size) {
+#if defined (DTLS_ATECC608A)
+  // priv_key et key_size are not used in ATECC608A
+  (void)priv_key;
+  (void)key_size;
+
+  unsigned char pub_key[2 * key_size];
+  ATCA_STATUS status = atcab_genkey(ecdhe_slot_id, pub_key);
+  if (status != ATCA_SUCCESS) {
+    dtls_crit("Failed to generate key\n");
+  }
+  else
+  {
+    memcpy(pub_key_x, pub_key, key_size);
+    memcpy(pub_key_y, pub_key + key_size, key_size);
+  }
+#else
   uint32_t priv[8];
   uint32_t pub_x[8];
   uint32_t pub_y[8];
@@ -477,6 +532,7 @@ dtls_ecdsa_generate_key(unsigned char *priv_key,
   dtls_ec_key_from_uint32(priv, key_size, priv_key);
   dtls_ec_key_from_uint32(pub_x, key_size, pub_key_x);
   dtls_ec_key_from_uint32(pub_y, key_size, pub_key_y);
+#endif /* DTLS_ATECC608A */
 }
 
 /* rfc4492#section-5.4 */
@@ -484,6 +540,22 @@ void
 dtls_ecdsa_create_sig_hash(const unsigned char *priv_key, size_t key_size,
 			   const unsigned char *sign_hash, size_t sign_hash_size,
 			   uint32_t point_r[9], uint32_t point_s[9]) {
+#if defined (DTLS_ATECC608A)
+  (void)sign_hash_size;
+  (void)priv_key;
+  ATCA_STATUS status;
+  unsigned char signature[2*key_size];
+  
+  status = atcab_sign(ecc_slot_id, sign_hash, signature);
+  if (status != ATCA_SUCCESS) {
+    dtls_crit("Failed to sign hash\n");
+  }
+  else
+  {
+    dtls_ec_key_to_uint32(signature, key_size, point_r);
+    dtls_ec_key_to_uint32(signature + key_size, key_size, point_s);
+  }
+#else
   int ret;
   uint32_t priv[8];
   uint32_t hash[8];
@@ -495,6 +567,7 @@ dtls_ecdsa_create_sig_hash(const unsigned char *priv_key, size_t key_size,
     dtls_prng((unsigned char *)randv, key_size);
     ret = ecc_ecdsa_sign(priv, hash, randv, point_r, point_s);
   } while (ret);
+#endif /* DTLS_ATECC608A */
 }
 
 void
@@ -522,6 +595,31 @@ dtls_ecdsa_verify_sig_hash(const unsigned char *pub_key_x,
 			   const unsigned char *pub_key_y, size_t key_size,
 			   const unsigned char *sign_hash, size_t sign_hash_size,
 			   unsigned char *result_r, unsigned char *result_s) {
+#if defined (DTLS_ATECC608A)
+  (void)sign_hash_size;
+  unsigned char pub_key[2 * key_size];
+  memcpy(pub_key, pub_key_x, key_size);
+  memcpy(pub_key + key_size, pub_key_y, key_size);
+  unsigned char signature[2 * key_size];
+  memcpy(signature, result_r, key_size);
+  memcpy(signature + key_size, result_s, key_size);
+
+  int is_verified = 0;
+
+  ATCA_STATUS status = atcab_verify_extern(sign_hash, signature, pub_key, (bool*)&is_verified);
+  if (status != ATCA_SUCCESS) {
+    dtls_alert("Failed to verify signature : %x\n", status);
+    is_verified = -1;
+  }
+  else 
+  {
+    if (is_verified == 0) {
+      dtls_alert("Signature is not verified\n");
+      is_verified = -1;
+    }
+  }
+  return is_verified;
+#else
   uint32_t pub_x[8];
   uint32_t pub_y[8];
   uint32_t hash[8];
@@ -535,6 +633,7 @@ dtls_ecdsa_verify_sig_hash(const unsigned char *pub_key_x,
   dtls_ec_key_to_uint32(sign_hash, sign_hash_size, hash);
 
   return ecc_ecdsa_validate(pub_x, pub_y, hash, point_r, point_s);
+#endif /* DTLS_ATECC608A */
 }
 
 int

--- a/crypto.h
+++ b/crypto.h
@@ -30,6 +30,10 @@
 #include "hmac.h"
 #include "ccm.h"
 
+#ifdef DTLS_ATECC608A
+#include "cryptoauthlib.h"
+#endif /* ATECC608A */
+
 /* TLS_PSK_WITH_AES_128_CCM_8 */
 #define DTLS_MAC_KEY_LENGTH    0
 #define DTLS_KEY_LENGTH        16 /* AES-128 */
@@ -219,6 +223,28 @@ typedef struct {
 
 /* just for consistency */
 #define dtls_kb_digest_size(Param, Role) DTLS_MAC_LENGTH
+
+#ifdef DTLS_ATECC608A
+/**
+ * @brief Slot id used to perform ECDHE operation. 
+ *        Due to the last 'E', the operation is performed with 
+ *        ephemeral keys that must be generated and stored in the
+ *        the current slot.
+ *        I advise to use slot configured as follows:
+ *          - SlotConfig[slot_id] = 0x2087
+ *          - KeyConfig[slot_id] = 0x0013
+ * @warning Slot ID must be different from ecc_slot_id.
+ */
+static uint8_t ecdhe_slot_id;
+
+/**
+ * @brief Slot id used to perform ECDSA operation.
+ *        This slot must contains the private key used to sign the
+ *        message. The associated public key is used to verify the signature.
+ * @warning Slot ID must be different from ecdhe_slot_id.
+ */
+static uint8_t ecc_slot_id;
+#endif
 
 /** 
  * Expands the secret and key to a block of DTLS_HMAC_MAX 
@@ -467,7 +493,12 @@ void dtls_handshake_free(dtls_handshake_parameters_t *handshake);
 dtls_security_parameters_t *dtls_security_new(void);
 
 void dtls_security_free(dtls_security_parameters_t *security);
+
+#ifndef DTLS_ATECC608A  
 void crypto_init(void);
+#else
+void crypto_init(ATCAIfaceCfg *config);
+#endif /* ATECC608A */
 
 #endif /* _DTLS_CRYPTO_H_ */
 

--- a/dtls.c
+++ b/dtls.c
@@ -324,6 +324,7 @@ free_context(dtls_context_t *context) {
 
 #endif /* WITH_POSIX */
 
+#ifndef DTLS_ATECC608A
 void
 dtls_init(void) {
   dtls_clock_init();
@@ -336,6 +337,26 @@ memarray_init(&dtlscontext_storage, dtlscontext_storage_data,
               sizeof(dtls_context_t), DTLS_CONTEXT_MAX);
 #endif /* RIOT_VERSION */
 }
+#else 
+void dtls_init(ATCAIfaceCfg *cfg)
+{
+  dtls_clock_init();
+  crypto_init(cfg);
+  netq_init();
+  peer_init();
+
+#ifdef RIOT_VERSION
+memarray_init(&dtlscontext_storage, dtlscontext_storage_data,
+              sizeof(dtls_context_t), DTLS_CONTEXT_MAX);
+#endif /* RIOT_VERSION */
+}
+
+void dtls_set_slot_id(uint8_t ecc_slot, uint8_t ecdhe_slot)
+{
+  ecdhe_slot_id = ecdhe_slot;
+  ecc_slot_id = ecc_slot;
+}
+#endif /* DTLS_ATECC608A */
 
 /* Calls cb_alert() with given arguments if defined, otherwise an
  * error message is logged and the result is -1. This is just an
@@ -653,7 +674,6 @@ static const dtls_user_parameters_t default_user_parameters = {
     {
 #ifdef DTLS_ECC
       TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8,
-      TLS_ECDHE_ECDSA_WITH_AES_128_CCM,
 #endif /* DTLS_ECC */
 #ifdef DTLS_PSK
       TLS_PSK_WITH_AES_128_CCM_8,
@@ -695,7 +715,6 @@ static const struct cipher_suite_param_t cipher_suite_params[] = {
 #endif /* DTLS_PSK */
 #ifdef DTLS_ECC
   { TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8,  8, DTLS_KEY_EXCHANGE_ECDHE_ECDSA },
-  { TLS_ECDHE_ECDSA_WITH_AES_128_CCM,   16, DTLS_KEY_EXCHANGE_ECDHE_ECDSA },
 #endif /* DTLS_ECC */
  };
 
@@ -2432,15 +2451,15 @@ check_client_certificate_verify(dtls_context_t *ctx,
   copy_hs_hash(peer, &hs_hash);
 
   dtls_hash_finalize(sha256hash, &hs_hash);
-
+  
   ret = dtls_ecdsa_verify_sig_hash(config->keyx.ecdsa.other_pub_x,
                                    config->keyx.ecdsa.other_pub_y,
                                    sizeof(config->keyx.ecdsa.other_pub_x),
                                    sha256hash, sizeof(sha256hash),
                                    result_r, result_s);
-
+                                   
   if (ret < 0) {
-    dtls_alert("wrong signature err: %i\n", ret);
+    dtls_alert("check_client_certificate_verify : wrong signature err: %i\n", ret);
     return dtls_alert_fatal_create(DTLS_ALERT_HANDSHAKE_FAILURE);
   }
   return 0;
@@ -2962,7 +2981,7 @@ dtls_send_client_key_exchange(dtls_context_t *ctx, dtls_peer_t *peer)
       p += DTLS_EC_KEY_SIZE;
       ephemeral_pub_y = p;
       p += DTLS_EC_KEY_SIZE;
-
+      
     dtls_ecdsa_generate_key(peer->handshake_params->keyx.ecdsa.own_eph_priv,
     			    ephemeral_pub_x, ephemeral_pub_y,
     			    DTLS_EC_KEY_SIZE);
@@ -3419,9 +3438,13 @@ check_server_certificate(dtls_context_t *ctx,
 	     config->keyx.ecdsa.other_pub_x,
 	     config->keyx.ecdsa.other_pub_y,
 	     sizeof(config->keyx.ecdsa.other_pub_x));
+       
   if (err < 0) {
     dtls_warn("The certificate was not accepted\n");
     return err;
+  }
+  else {
+    dtls_debug("The certificate was accepted\n");
   }
 
   return 0;
@@ -3458,14 +3481,14 @@ check_server_key_exchange_ecdsa(dtls_context_t *ctx,
   key_params = data;
 
   if (dtls_uint8_to_int(data) != TLS_EC_CURVE_TYPE_NAMED_CURVE) {
-    dtls_alert("Only named curves supported\n");
+    dtls_alert("Only named curves supported : %d\n", dtls_uint8_to_int(data));
     return dtls_alert_fatal_create(DTLS_ALERT_HANDSHAKE_FAILURE);
   }
   data += sizeof(uint8);
   data_length -= sizeof(uint8);
 
   if (dtls_uint16_to_int(data) != TLS_EXT_ELLIPTIC_CURVES_SECP256R1) {
-    dtls_alert("secp256r1 supported\n");
+    dtls_alert("secp256r1 supported : %d\n", dtls_uint16_to_int(data));
     return dtls_alert_fatal_create(DTLS_ALERT_HANDSHAKE_FAILURE);
   }
   data += sizeof(uint16);
@@ -3509,7 +3532,7 @@ check_server_key_exchange_ecdsa(dtls_context_t *ctx,
 			    result_r, result_s);
 
   if (ret < 0) {
-    dtls_alert("wrong signature\n");
+    dtls_alert("check_server_key_exchange_ecdsa : wrong signature\n");
     return dtls_alert_fatal_create(DTLS_ALERT_HANDSHAKE_FAILURE);
   }
   return 0;

--- a/dtls.h
+++ b/dtls.h
@@ -40,6 +40,10 @@
 #include "global.h"
 #include "dtls_time.h"
 
+#ifdef DTLS_ATECC608A
+#include "cryptoauthlib.h"
+#endif /* ATECC608A */
+
 #ifndef DTLSv12
 #define DTLS_VERSION 0xfeff	/* DTLS v1.1 */
 #else
@@ -244,7 +248,22 @@ typedef struct dtls_context_t {
  * This function initializes the tinyDTLS memory management and must
  * be called first.
  */
+#ifndef DTLS_ATECC608A
 void dtls_init(void);
+
+#else
+void dtls_init(ATCAIfaceCfg *cfg);
+
+/**
+ * @brief Set the slot id used to perform ECDHE operation.
+ * @warning Slot ID must be different.
+ * @param ecc_slot Slot ID used to perform ECDSA operation.
+ * @param ecdhe_slot Slot ID used to perform ECDHE operation.
+ */
+void dtls_set_slot_id(uint8_t ecc_slot, uint8_t ecdhe_slot);
+
+void dtls_test_ATECC608A(void);
+#endif /* ATECC608A */
 
 /** 
  * Creates a new context object. The storage allocated for the new


### PR DESCRIPTION
I am working on boards that embed an ATECC608A (Microchip secure element), and I would like to perform all ECC/ECDH operations using it. This approach offers the benefit of enhanced security, as private keys are not directly manipulated.

Initially, I am working with RIOT. When I started looking for solutions to secure RF communication, I came across tinydtls and was convinced by its implementation of DTLS. I noticed some issues on my board (reported here [Issue 224](https://github.com/eclipse/tinydtls/issues/224)), and a PR to replace ecc with micro-ecc is now open ([PR 229](https://github.com/eclipse/tinydtls/pull/229)).

Micro-ecc works on my boards and significantly accelerates the handshake process. However, as mentioned earlier, I have an ATECC608A on my boards, so I would like to add a feature allowing users to choose whether to use it or not.

Since not all boards embed a secure element, I have added an environment variable (DTLS_ATECC608A) to give users the choice to use it or not. The CryptoAuth library is used to control the secure element ([CryptoAuthLib](https://github.com/MicrochipTech/cryptoauthlib)).

This PR is still a work in progress, but I have opened it so that we can discuss and improve my work.