### PR TITLE
dtls.c: enforce the default dtls user params to be configurable

### DIFF
--- a/crypto.h
+++ b/crypto.h
@@ -94,6 +94,16 @@ typedef struct {
 /* This is the maximal supported length of the pre-shared key. */
 #define DTLS_PSK_MAX_KEY_LEN DTLS_KEY_LENGTH
 
+/* Ensure that extended master secret is forced in DTLS connections */
+#ifndef DTLS_FORCE_EXTENDED_MASTER_SECRET
+#define DTLS_FORCE_EXTENDED_MASTER_SECRET   (1)
+#endif
+
+/* Ensure that renegotiation info is forced in DTLS connections */
+#ifndef DTLS_FORCE_RENEGOTIATION_INFO
+#define DTLS_FORCE_RENEGOTIATION_INFO   (1)
+#endif
+
 typedef struct {
   uint16_t id_length;
   unsigned char identity[DTLS_PSK_MAX_CLIENT_IDENTITY_LEN];

--- a/dtls.c
+++ b/dtls.c
@@ -664,8 +664,8 @@ static const dtls_user_parameters_t default_user_parameters = {
        TLS_NULL_WITH_NULL_NULL
     },
 #endif /* DTLS_DEFAULT_CIPHER_SUITES */
-  .force_extended_master_secret = 1,
-  .force_renegotiation_info = 1,
+  .force_extended_master_secret = DTLS_FORCE_EXTENDED_MASTER_SECRET,
+  .force_renegotiation_info = DTLS_FORCE_RENEGOTIATION_INFO,
 };
 
 /** only one compression method is currently defined */


### PR DESCRIPTION
Contribution description
Incorporating the tinydtls build package, this code addresses a failure encountered during the DTLS handshake between the client and the server. The issue arose from the client imposing default user parameters, which mandate setting extended master secret and renegotiation info to 1. However, not all servers support these extensions. To ensure greater flexibility, it's more appropriate to make these parameters user-configurable.

Testing procedure
I utilized the 'examples/gcoap_dtls' from RIOT OS on a native environment for the client. However, for the server, I deployed it on my Ubuntu machine, which lacks support for these extensions

results when the extensions are set to 0:

```
2024-03-18 16:45:30,983 # RIOT native interrupts/signals initialized.
2024-03-18 16:45:30,984 # RIOT native board initialized.
2024-03-18 16:45:30,985 # RIOT native hardware initialization complete.
2024-03-18 16:45:30,985 # 
2024-03-18 16:45:30,986 # main(): This is RIOT! (Version: 2024.04-devel-390-ge5f033-Mariem/dtls_default_user_params_fix)
2024-03-18 16:45:30,987 # default credentials will be used
2024-03-18 16:45:30,987 # gcoap example app
2024-03-18 16:45:30,988 # All up, running the shell now
nib route add 7 :: fe80::58da:6eff:fe50:5b94re
2024-03-18 16:45:33,294 # nib route add 7 :: fe80::58da:6eff:fe50:5b94
coap get "[fe80::58da:6eff:fe50:5b94%7]" /.well-known/core
2024-03-18 16:45:34,715 # coap get "[fe80::58da:6eff:fe50:5b94%7]" /.well-known/core
2024-03-18 16:45:34,716 # gcoap_cli: sending msg ID 42940, 23 bytes
> 2024-03-18 16:45:34,774 # gcoap: response Success, code 2.05, 455 bytes
2024-03-18 16:45:34,776 # </fw>,</fw/1>;title="Retrieve a firmware update",</fw/1/d>,</fw/1/d/42>,</fw/1/m>,</fw/1/m/AAAAAA>,</fw/2>;title="Retrieve a firmware update, API version 2",</fw/2/d>,</fw/2/d/42>,</fw/2/m>,</fw/2/m/AAAAAA>,</t>,</t/1>;title="Retrieve system time in milliseconds since unix epoch",</din>,</din/1>;title="Data Record Input, version 1",</din/1/AAAAAA>,</cmd>,</cmd/1>;title="Retrieve commands for execution on the device",</cmd/1/AAAAAA>,</.well-known/core>
```

results when the extensions are set to 1:

```
2024-03-18 16:45:56,159 # main(): This is RIOT! (Version: 2024.04-devel-390-ge5f033-Mariem/dtls_default_user_params_fix)
2024-03-18 16:45:56,159 # default credentials will be used
2024-03-18 16:45:56,160 # gcoap example app
2024-03-18 16:45:56,160 # All up, running the shell now
nib route add 7 :: fe80::58da:6eff:fe50:5b94
2024-03-18 16:45:58,584 # nib route add 7 :: fe80::58da:6eff:fe50:5b94
coap get "[fe80::58da:6eff:fe50:5b94%7]" /.well-known/core
2024-03-18 16:46:00,738 # coap get "[fe80::58da:6eff:fe50:5b94%7]" /.well-known/core
2024-03-18 16:46:00,738 # gcoap_cli: sending msg ID 19650, 23 bytes
2024-03-18 16:46:00,745 # error in check_server_hello err: -552
2024-03-18 16:46:00,746 # error 0x0228 handling handshake packet of type: server_hello (2), state 8
```