### PR TITLE
doc/Makefile.in: Update Doxyfile to latest version before use

### DIFF
--- a/doc/Makefile.in
+++ b/doc/Makefile.in
@@ -18,7 +18,8 @@ DISTDIR?=$(top_builddir)/@PACKAGE_TARNAME@-@PACKAGE_VERSION@
 FILES:=Makefile.in Doxyfile.in html
 
 doc:	Doxyfile
-	$(DOXYGEN) -l
+	@$(DOXYGEN) -u $< > /dev/null 2>&1
+	@$(DOXYGEN) -l
 	$(DOXYGEN) $< >./doxygen.out
 
 clean:


### PR DESCRIPTION
Add in '$(DOXYGEN) -u' to update Doxyfile to the latest version to reduce any old configuration warning errors.