### PR TITLE
fix(dtls): remove duplicate DEL_PEER in handle_alert()

### DIFF
--- a/dtls.c
+++ b/dtls.c
@@ -4502,10 +4502,9 @@ handle_alert(dtls_context_t *ctx, dtls_peer_t *peer,
   dtls_info("** Alert: level %d, description %d\n", data[0], data[1]);
 
   /* The peer object is invalidated for FATAL alerts and close
-   * notifies. This is done in two steps.: First, remove the object
-   * from our list of peers. After that, the event handler callback is
-   * invoked with the still existing peer object. Finally, the storage
-   * used by peer is released.
+   * notifies. The event handler callback is invoked with the peer
+   * object, then dtls_destroy_peer() removes the peer from the
+   * hash table and releases the storage.
    */
   close_notify = data[1] == DTLS_ALERT_CLOSE_NOTIFY;
   if (data[0] == DTLS_ALERT_LEVEL_FATAL || close_notify) {
@@ -4513,8 +4512,6 @@ handle_alert(dtls_context_t *ctx, dtls_peer_t *peer,
       dtls_info("invalidate peer (Close Notify)\n");
     else
       dtls_alert("%d invalidate peer\n", data[1]);
-
-    DEL_PEER(ctx->peers, peer);
 
 #ifdef WITH_CONTIKI
 #ifndef NDEBUG


### PR DESCRIPTION
## Summary
- Remove duplicate `DEL_PEER()` call in `handle_alert()` to fix uthash corruption

## Problem
`handle_alert()` calls `DEL_PEER()` to remove the peer from the hash table, then calls `dtls_destroy_peer()` which calls `DEL_PEER()` again on the same peer. Since `HASH_DELETE_HH` in uthash does not check if the entry is in the table, this double removal corrupts the hash table bucket chains and `num_items` counter, potentially leading to crashes or use-after-free.

## Fix
Remove the `DEL_PEER()` call from `handle_alert()` since `dtls_destroy_peer()` already handles the complete peer cleanup including removal from the hash table.

## Changes
| File | Change |
|------|--------|
| `dtls.c` | Remove duplicate `DEL_PEER()` in `handle_alert()`, update comment |

Fixes #269